### PR TITLE
Add context menu for tab management

### DIFF
--- a/V3-1-7.html
+++ b/V3-1-7.html
@@ -361,6 +361,7 @@ let modulesDirHandle = null;
 let liveModuleTemplates = [];
 let tabs = [];
 let activeTabIndex = 0;
+let tabContextMenu = null;
 // Start with sidebar closed by default
 let isSidebarOpen = false;
 
@@ -1065,17 +1066,8 @@ function renderTabs() {
     label.className = 'truncate max-w-xs';
     label.textContent = tab.name;
     item.appendChild(label);
-    const closeBtn = document.createElement('span');
-    closeBtn.className = 'close-btn text-base';
-    closeBtn.textContent = '×';
-    closeBtn.title = 'Tab löschen';
-    closeBtn.addEventListener('click', e => {
-      e.stopPropagation();
-      if (!confirm('Tab wirklich löschen?')) return;
-      deleteTab(idx);
-    });
-    item.appendChild(closeBtn);
     item.addEventListener('click', () => activateTab(idx));
+    item.addEventListener('contextmenu', e => openTabContextMenu(e, idx));
     tabsContainer.appendChild(item);
   });
 }
@@ -1098,6 +1090,57 @@ function deleteTab(idx) {
   activateTab(activeTabIndex);
   saveLayout();
 }
+
+/** Rename tab */
+function renameTab(idx) {
+  const newName = prompt('Neuer Name für den Tab:', tabs[idx].name);
+  if (newName) {
+    tabs[idx].name = newName;
+    renderTabs();
+    saveLayout();
+  }
+}
+
+/** Open context menu for a tab */
+function openTabContextMenu(e, idx) {
+  e.preventDefault();
+  closeTabContextMenu();
+  const menu = document.createElement('div');
+  menu.className = 'tab-context-menu absolute bg-white border rounded shadow z-50 text-sm';
+  menu.style.left = e.pageX + 'px';
+  menu.style.top = e.pageY + 'px';
+
+  const renameItem = document.createElement('div');
+  renameItem.className = 'px-3 py-1 hover:bg-gray-100 cursor-pointer';
+  renameItem.textContent = 'Namen bearbeiten';
+  renameItem.addEventListener('click', () => {
+    closeTabContextMenu();
+    renameTab(idx);
+  });
+  menu.appendChild(renameItem);
+
+  const deleteItem = document.createElement('div');
+  deleteItem.className = 'px-3 py-1 hover:bg-gray-100 cursor-pointer';
+  deleteItem.textContent = 'Tab löschen';
+  deleteItem.addEventListener('click', () => {
+    closeTabContextMenu();
+    if (!confirm('Tab wirklich löschen?')) return;
+    deleteTab(idx);
+  });
+  menu.appendChild(deleteItem);
+
+  document.body.appendChild(menu);
+  tabContextMenu = menu;
+}
+
+function closeTabContextMenu() {
+  if (tabContextMenu) {
+    tabContextMenu.remove();
+    tabContextMenu = null;
+  }
+}
+
+document.addEventListener('click', () => closeTabContextMenu());
 
 /** Remove all tabs */
 function resetTabs() {


### PR DESCRIPTION
## Summary
- Replace tab close button with right-click context menu
- Enable renaming tabs and deletion via context menu

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c1158fd610832d960d6cfd7f8f194c