### PR TITLE
Add toggle to control grid float behavior

### DIFF
--- a/V3-1-7.html
+++ b/V3-1-7.html
@@ -222,6 +222,19 @@
             <label>Primäre Buttontextfarbe</label>
             <input type="color" id="setting-button-text" value="#ffffff" class="w-full border rounded p-1">
           </div>
+          <div class="form-field col-span-2">
+            <div class="flex items-center justify-between gap-4">
+              <div>
+                <label for="setting-grid-float">Automatisches Nachrücken</label>
+                <p class="text-xs text-gray-500">Module rücken Lücken automatisch nach oben, wenn diese Option aktiv ist.</p>
+              </div>
+              <label for="setting-grid-float" class="relative inline-flex items-center cursor-pointer">
+                <input type="checkbox" id="setting-grid-float" class="sr-only peer">
+                <div class="w-11 h-6 bg-gray-300 rounded-full transition peer-focus:ring-2 peer-focus:ring-blue-300 peer-checked:bg-blue-600"></div>
+                <span class="absolute left-1 top-1 h-4 w-4 rounded-full bg-white transition-transform peer-checked:translate-x-5"></span>
+              </label>
+            </div>
+          </div>
         </div>
       </div>
       <!-- Topbar section -->
@@ -335,6 +348,7 @@ let appSettings = {
   buttonBg: '#2563eb',
   buttonText: '#ffffff',
   borderColor: '#e5e7eb',
+  gridFloat: true,
   moduleBgColor: '#005983',
   textColor: '#ffffff',
   moduleBorderRadius: '1.25rem',
@@ -408,6 +422,7 @@ const inputTabInactiveText = document.getElementById('setting-tab-inactive-text'
 const inputSidebarBg = document.getElementById('setting-sidebar-bg');
 const inputSidebarText = document.getElementById('setting-sidebar-text');
 const inputGridHint = document.getElementById('setting-grid-hint');
+const inputGridFloat = document.getElementById('setting-grid-float');
 const inputModuleBg = document.getElementById('setting-module-bg');
 const inputTextColor = document.getElementById('setting-text-color');
 const inputBorderRadius = document.getElementById('setting-border-radius');
@@ -611,6 +626,12 @@ document.addEventListener('DOMContentLoaded', async () => {
       renderTabs();
     });
   });
+  if (inputGridFloat) {
+    inputGridFloat.addEventListener('change', () => {
+      readInputsIntoSettings();
+      applySettings();
+    });
+  }
   inputBorderRadius.addEventListener('input', () => {
     appSettings.moduleBorderRadius = ((parseFloat(inputBorderRadius.value)||0)/16) + 'rem';
     applySettings();
@@ -622,6 +643,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   activateTab(0);
   updateModuleDraggable();
   updateGridDraggable();
+  updateGridFloat();
 
   // --- Try to restore AFTER wiring handlers ---
   const restored = await tryRestoreRootHandle();
@@ -648,6 +670,7 @@ function populateInputsFromSettings() {
   inputSidebarBg.value = toColor(appSettings.sidebarBg, inputSidebarBg.value);
   inputSidebarText.value = toColor(appSettings.sidebarText, inputSidebarText.value);
   inputGridHint.value = toColor(appSettings.gridHint, inputGridHint.value);
+  if (inputGridFloat) inputGridFloat.checked = !!appSettings.gridFloat;
   inputModuleBg.value = toColor(appSettings.moduleBgColor, inputModuleBg.value);
   inputTextColor.value = toColor(appSettings.textColor, inputTextColor.value);
   inputBorderRadius.value = Math.round(parseFloat(appSettings.moduleBorderRadius) * 16 || 0);
@@ -677,6 +700,7 @@ function readInputsIntoSettings() {
   appSettings.sidebarBg = inputSidebarBg.value;
   appSettings.sidebarText = inputSidebarText.value;
   appSettings.gridHint = inputGridHint.value;
+  if (inputGridFloat) appSettings.gridFloat = inputGridFloat.checked;
   appSettings.moduleBgColor = inputModuleBg.value;
   appSettings.textColor = inputTextColor.value;
   appSettings.moduleBorderRadius = ((parseFloat(inputBorderRadius.value)||0)/16) + 'rem';
@@ -733,6 +757,8 @@ function applySettings() {
   document.documentElement.style.setProperty('--sidebar-module-card-bg', appSettings.sidebarModuleCardBg);
   document.documentElement.style.setProperty('--sidebar-module-card-text', appSettings.sidebarModuleCardText);
   document.documentElement.style.setProperty('--sidebar-module-card-border', appSettings.sidebarModuleCardBorder);
+
+  updateGridFloat();
 }
 
 /** Save settings to storage */
@@ -796,6 +822,25 @@ function updateGridDraggable() {
           if (!isSidebarOpen) handle.style.cursor = 'default';
         });
       });
+    }
+  });
+}
+
+function updateGridFloat() {
+  const shouldFloat = !!appSettings.gridFloat;
+  tabs.forEach(tab => {
+    const grid = tab.grid;
+    if (!grid) return;
+    if (typeof grid.float === 'function') {
+      grid.float(shouldFloat);
+    } else if (typeof grid.setFloat === 'function') {
+      grid.setFloat(shouldFloat);
+    } else {
+      grid.opts = grid.opts || {};
+      grid.opts.float = shouldFloat;
+      if (grid.engine && Object.prototype.hasOwnProperty.call(grid.engine, 'float')) {
+        grid.engine.float = shouldFloat;
+      }
     }
   });
 }
@@ -1036,6 +1081,7 @@ async function loadAndInitTabs() {
   // ensure initial state reflects current sidebar state
   updateModuleDraggable();
   updateGridDraggable();
+  updateGridFloat();
 }
 
 /** Create a tab and grid */
@@ -1048,7 +1094,7 @@ function createTab(name, layoutModules = []) {
   gridEl.dataset.tabIndex = tabIndex;
   gridsContainer.appendChild(gridEl);
 
-  const gridInstance = GridStack.init({ cellHeight: 30, margin: 5, handle: '.grid-stack-item-content', column: 12, float: true, minRow: 8 }, gridEl);
+  const gridInstance = GridStack.init({ cellHeight: 30, margin: 5, handle: '.grid-stack-item-content', column: 12, float: !!appSettings.gridFloat, minRow: 8 }, gridEl);
 
   // Reflect current sidebar state immediately (no drag/resize when closed)
   gridInstance.setStatic(!isSidebarOpen);


### PR DESCRIPTION
## Summary
- add an "Automatisches Nachrücken" switch to the general settings so users can choose whether grids float
- persist the new gridFloat preference and wire it into tab creation and existing grids

## Testing
- not run (static HTML page)


------
https://chatgpt.com/codex/tasks/task_e_68cba7375b78832db45564c9efba033c