### PR TITLE
Fix LinkButtonsPlus context menu propagation

### DIFF
--- a/modules/LinkButtonsPlus/LinkButtonsPlus.js
+++ b/modules/LinkButtonsPlus/LinkButtonsPlus.js
@@ -471,6 +471,7 @@
 
     root.addEventListener('contextmenu', e => {
       e.preventDefault();
+      e.stopPropagation();
       workforceFilters = loadWorkforceFilters();
       renderFilters();
       tabButtons.forEach(btn => {


### PR DESCRIPTION
## Summary
- ensure the LinkButtonsPlus context menu suppresses parent context-menu handlers by stopping event propagation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cbc5c38518832d93e3d5ae7eb34a7c