### PR TITLE
Add cross-browser file access fallbacks for Luna modules

### DIFF
--- a/modules/Luna/RecordViewer/RecordViewer.js
+++ b/modules/Luna/RecordViewer/RecordViewer.js
@@ -99,6 +99,17 @@
     return null;
   }
 
+  async function readFileFromFallback(path){
+    const store = window.__lunaFallbackFiles;
+    if(store && typeof store.get === 'function'){
+      const file = store.get(path);
+      if(file){
+        return await file.text();
+      }
+    }
+    return null;
+  }
+
   async function loadAndRender(root){
     const path = getPath();
     if(!path){
@@ -106,7 +117,10 @@
       return;
     }
     try{
-      let text = await readFileFromHandles(path);
+      let text = await readFileFromFallback(path);
+      if(text == null){
+        text = await readFileFromHandles(path);
+      }
       if(text == null){
         // fall back to fetch for non-local paths
         const res = await fetch(path);


### PR DESCRIPTION
## Summary
- add a hidden directory file input fallback to RecentFiles so folder selection works when the File System Access API is unavailable
- share selected files through a global map for consumption by RecordViewer
- allow RecordViewer to read recent files from the fallback map before trying persisted handles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd21a4cc688321b72531fda61e5337