### PR TITLE
Expand grid drop zone to full viewport height

### DIFF
--- a/V3-1-7.html
+++ b/V3-1-7.html
@@ -454,9 +454,35 @@ function calculateAvailableGridHeight() {
   return Math.max(window.innerHeight - topBarHeight, 0);
 }
 
-function applyGridMinHeight(gridEl) {
-  if (!gridEl) return;
-  gridEl.style.minHeight = calculateAvailableGridHeight() + 'px';
+function parseMarginValue(value, fallback = 0) {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const parsed = parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+  return fallback;
+}
+
+function adjustGridMinRows(gridInstance, minHeight) {
+  if (!gridInstance) return;
+  const cellHeight = typeof gridInstance.getCellHeight === 'function'
+    ? gridInstance.getCellHeight()
+    : parseMarginValue(gridInstance.opts?.cellHeight, 0);
+  const opts = gridInstance.opts || {};
+  const baseMargin = parseMarginValue(opts.margin, 0);
+  const marginTop = parseMarginValue(opts.marginTop, baseMargin);
+  const marginBottom = parseMarginValue(opts.marginBottom, baseMargin);
+  const rowHeight = Math.max(cellHeight + marginTop + marginBottom, 1);
+  const requiredRows = Math.max(Math.ceil(minHeight / rowHeight), parseMarginValue(opts.minRow, 0));
+  if (requiredRows !== opts.minRow) {
+    gridInstance.updateOptions({ minRow: requiredRows });
+  }
+}
+
+function applyGridMinHeight(gridEl, gridInstance, minHeightOverride) {
+  const minHeight = typeof minHeightOverride === 'number' ? minHeightOverride : calculateAvailableGridHeight();
+  if (gridEl) gridEl.style.minHeight = minHeight + 'px';
+  adjustGridMinRows(gridInstance, minHeight);
 }
 
 function updateAllGridMinHeights() {
@@ -464,6 +490,7 @@ function updateAllGridMinHeights() {
   if (gridsContainer) gridsContainer.style.minHeight = minHeight + 'px';
   tabs.forEach(tab => {
     if (tab.el) tab.el.style.minHeight = minHeight + 'px';
+    applyGridMinHeight(null, tab.grid, minHeight);
   });
 }
 
@@ -1135,11 +1162,12 @@ function createTab(name, layoutModules = []) {
   const tab = { name: name || ('Tab ' + (tabIndex + 1)), modules: [], grid: null, el: null };
   const gridEl = document.createElement('div');
   gridEl.className = 'grid-stack p-4';
-  applyGridMinHeight(gridEl);
   gridEl.dataset.tabIndex = tabIndex;
   gridsContainer.appendChild(gridEl);
 
   const gridInstance = GridStack.init({ cellHeight: 30, margin: 5, handle: '.grid-stack-item-content', column: 12, float: !appSettings.autoArrangeModules, minRow: 8 }, gridEl);
+
+  applyGridMinHeight(gridEl, gridInstance);
 
   // Reflect current sidebar state immediately (no drag/resize when closed)
   gridInstance.setStatic(!isSidebarOpen);

--- a/V3-1-7.html
+++ b/V3-1-7.html
@@ -406,6 +406,7 @@ function generateInstanceId() {
 const listEl = document.getElementById('module-list');
 const gridsContainer = document.getElementById('grids');
 const tabsContainer = document.getElementById('tabs-container');
+const topBarEl = document.getElementById('top-bar');
 const addTabBtn = document.getElementById('add-tab');
 const sidebarEl = document.getElementById('sidebar');
 const sidebarToggle = document.getElementById('sidebar-toggle');
@@ -447,6 +448,26 @@ const settingsNavButtons = document.querySelectorAll('.settings-nav button');
 
 // Remember the selected root folder across sessions
 const FS_HANDLE_KEY = 'rootDirHandle';
+
+function calculateAvailableGridHeight() {
+  const topBarHeight = topBarEl ? topBarEl.getBoundingClientRect().height : 0;
+  return Math.max(window.innerHeight - topBarHeight, 0);
+}
+
+function applyGridMinHeight(gridEl) {
+  if (!gridEl) return;
+  gridEl.style.minHeight = calculateAvailableGridHeight() + 'px';
+}
+
+function updateAllGridMinHeights() {
+  const minHeight = calculateAvailableGridHeight();
+  if (gridsContainer) gridsContainer.style.minHeight = minHeight + 'px';
+  tabs.forEach(tab => {
+    if (tab.el) tab.el.style.minHeight = minHeight + 'px';
+  });
+}
+
+window.addEventListener('resize', updateAllGridMinHeights);
 
 function idbOpen() {
   return new Promise((res, rej) => {
@@ -649,6 +670,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   updateModuleDraggable();
   updateGridDraggable();
   updateGridAutoArrange();
+  updateAllGridMinHeights();
 
   // --- Try to restore AFTER wiring handlers ---
   const restored = await tryRestoreRootHandle();
@@ -1104,6 +1126,7 @@ async function loadAndInitTabs() {
   updateModuleDraggable();
   updateGridDraggable();
   updateGridAutoArrange();
+  updateAllGridMinHeights();
 }
 
 /** Create a tab and grid */
@@ -1112,7 +1135,7 @@ function createTab(name, layoutModules = []) {
   const tab = { name: name || ('Tab ' + (tabIndex + 1)), modules: [], grid: null, el: null };
   const gridEl = document.createElement('div');
   gridEl.className = 'grid-stack p-4';
-  gridEl.style.minHeight = 'calc(100vh - 40px)';
+  applyGridMinHeight(gridEl);
   gridEl.dataset.tabIndex = tabIndex;
   gridsContainer.appendChild(gridEl);
 
@@ -1213,6 +1236,9 @@ function renderTabs() {
     onStart: closeTabContextMenu,
     onEnd: handleTabReorder
   });
+
+  // Tab content height depends on how tall the top bar is after rendering
+  setTimeout(updateAllGridMinHeights, 0);
 }
 
 /** Handle tab drag-and-drop reorder */

--- a/V3-1-7.html
+++ b/V3-1-7.html
@@ -450,8 +450,10 @@ const settingsNavButtons = document.querySelectorAll('.settings-nav button');
 const FS_HANDLE_KEY = 'rootDirHandle';
 
 function calculateAvailableGridHeight() {
-  const topBarHeight = topBarEl ? topBarEl.getBoundingClientRect().height : 0;
-  return Math.max(window.innerHeight - topBarHeight, 0);
+  const viewportHeight = window.innerHeight || document.documentElement?.clientHeight || 0;
+  if (!gridsContainer) return Math.max(viewportHeight, 0);
+  const containerRect = gridsContainer.getBoundingClientRect();
+  return Math.max(viewportHeight - containerRect.top, 0);
 }
 
 function parseMarginValue(value, fallback = 0) {
@@ -496,15 +498,24 @@ function adjustGridMinRows(gridInstance, minHeight) {
 
 function applyGridMinHeight(gridEl, gridInstance, minHeightOverride) {
   const minHeight = typeof minHeightOverride === 'number' ? minHeightOverride : calculateAvailableGridHeight();
-  if (gridEl) gridEl.style.minHeight = minHeight + 'px';
+  if (gridEl) {
+    gridEl.style.minHeight = minHeight + 'px';
+    gridEl.style.height = minHeight + 'px';
+  }
   adjustGridMinRows(gridInstance, minHeight);
 }
 
 function updateAllGridMinHeights() {
   const minHeight = calculateAvailableGridHeight();
-  if (gridsContainer) gridsContainer.style.minHeight = minHeight + 'px';
+  if (gridsContainer) {
+    gridsContainer.style.minHeight = minHeight + 'px';
+    gridsContainer.style.height = minHeight + 'px';
+  }
   tabs.forEach(tab => {
-    if (tab.el) tab.el.style.minHeight = minHeight + 'px';
+    if (tab.el) {
+      tab.el.style.minHeight = minHeight + 'px';
+      tab.el.style.height = minHeight + 'px';
+    }
     applyGridMinHeight(null, tab.grid, minHeight);
   });
 }

--- a/V3-1-7.html
+++ b/V3-1-7.html
@@ -463,19 +463,34 @@ function parseMarginValue(value, fallback = 0) {
   return fallback;
 }
 
+function readGridCellHeight(gridInstance) {
+  if (!gridInstance) return 0;
+  if (typeof gridInstance.getCellHeight === 'function') {
+    return parseMarginValue(gridInstance.getCellHeight(), 0);
+  }
+  if (typeof gridInstance.cellHeight === 'function') {
+    return parseMarginValue(gridInstance.cellHeight(), 0);
+  }
+  return parseMarginValue(gridInstance.opts?.cellHeight, 0);
+}
+
 function adjustGridMinRows(gridInstance, minHeight) {
-  if (!gridInstance) return;
-  const cellHeight = typeof gridInstance.getCellHeight === 'function'
-    ? gridInstance.getCellHeight()
-    : parseMarginValue(gridInstance.opts?.cellHeight, 0);
+  if (!gridInstance || !Number.isFinite(minHeight)) return;
+
   const opts = gridInstance.opts || {};
+  const cellHeight = readGridCellHeight(gridInstance);
   const baseMargin = parseMarginValue(opts.margin, 0);
   const marginTop = parseMarginValue(opts.marginTop, baseMargin);
   const marginBottom = parseMarginValue(opts.marginBottom, baseMargin);
   const rowHeight = Math.max(cellHeight + marginTop + marginBottom, 1);
   const requiredRows = Math.max(Math.ceil(minHeight / rowHeight), parseMarginValue(opts.minRow, 0));
-  if (requiredRows !== opts.minRow) {
+
+  if (requiredRows === opts.minRow) return;
+
+  if (typeof gridInstance.updateOptions === 'function') {
     gridInstance.updateOptions({ minRow: requiredRows });
+  } else if (gridInstance.opts) {
+    gridInstance.opts.minRow = requiredRows;
   }
 }
 


### PR DESCRIPTION
## Summary
- add helpers to compute available viewport space below the top bar and update grid containers accordingly
- ensure each grid tab and the grid container maintain a minimum height that reaches the bottom of the window
- refresh the minimum height after rendering tabs, loading layouts, and whenever the window is resized

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1519d7db8832196d230e2993c4373