### PR TITLE
Add update management UI and background checks

### DIFF
--- a/V3-1-7.html
+++ b/V3-1-7.html
@@ -141,6 +141,87 @@
       max-height: 50vh;
       overflow-y: auto;
     }
+    .update-settings-row {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem 0.75rem;
+    }
+    .update-settings-row .update-folder-info {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .update-toggle {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      cursor: pointer;
+    }
+    .update-toggle input {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0,0,0,0);
+      white-space: nowrap;
+      border: 0;
+    }
+    .update-toggle-track {
+      width: 2.75rem;
+      height: 1.5rem;
+      background-color: #d1d5db;
+      border-radius: 9999px;
+      transition: background-color 0.2s ease;
+    }
+    .update-toggle-thumb {
+      position: absolute;
+      left: 0.25rem;
+      top: 0.25rem;
+      width: 1rem;
+      height: 1rem;
+      border-radius: 9999px;
+      background-color: white;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+      transition: transform 0.2s ease;
+    }
+    .update-toggle input:checked + .update-toggle-track {
+      background-color: #2563eb;
+    }
+    .update-toggle input:checked + .update-toggle-track + .update-toggle-thumb {
+      transform: translateX(1.25rem);
+    }
+    .version-overview-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 5rem 5rem;
+      column-gap: 1.5rem;
+      row-gap: 0.5rem;
+      align-items: center;
+    }
+    .version-overview-header {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #6b7280;
+    }
+    .version-overview-name {
+      font-weight: 500;
+      color: #374151;
+    }
+    .version-overview-value {
+      text-align: right;
+      font-variant-numeric: tabular-nums;
+      color: #4b5563;
+    }
+    .version-overview-empty {
+      grid-column: 1 / -1;
+      color: #6b7280;
+      font-style: italic;
+    }
     .settings-nav button {
       border-radius: .5rem;
       padding: .5rem .75rem;
@@ -189,9 +270,11 @@
   <header id="top-bar" class="flex items-center gap-1 px-3 py-2 shadow" style="height:40px">
     <div id="tabs-container" class="flex items-center gap-1 flex-wrap"></div>
     <button id="add-tab" title="Neuen Tab erstellen" class="text-xl px-2 py-1 leading-none hover:opacity-80">➕</button>
-    <button id="update-status" class="ml-auto text-sm px-3 py-1 rounded mr-2 hidden">Update prüfen</button>
-    <button id="select-root" class="text-sm px-3 py-1 rounded">Ordner wählen</button>
-    <button id="open-settings" title="Einstellungen" class="bg-gray-300 hover:bg-gray-400 text-gray-800 text-sm px-3 py-1 rounded ml-2">⚙️</button>
+    <div class="ml-auto flex items-center gap-2">
+      <button id="update-status" class="text-sm px-3 py-1 rounded hidden">Update prüfen</button>
+      <button id="select-root" class="text-sm px-3 py-1 rounded">Ordner wählen</button>
+      <button id="open-settings" title="Einstellungen" class="bg-gray-300 hover:bg-gray-400 text-gray-800 text-sm px-3 py-1 rounded">⚙️</button>
+    </div>
   </header>
   <div class="flex" style="height: calc(100% - 40px);">
     <aside id="sidebar" class="w-72 min-h-full p-3 relative transition-all duration-300 ease-in-out">
@@ -349,18 +432,22 @@
       </div>
         <div id="section-updates" class="settings-section">
           <div class="space-y-4">
-            <div class="flex flex-col gap-3 text-sm">
-              <div class="flex flex-wrap items-center gap-2">
-                <span class="font-medium">Update-Ordner:</span>
-                <span id="update-folder-name" class="px-2 py-1 bg-gray-100 rounded">Keiner gewählt</span>
-                <button id="select-update-folder" class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded">Ordner wählen</button>
-                <button id="clear-update-folder" class="bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-1 rounded">Zurücksetzen</button>
-                <span id="update-check-status" class="text-gray-500"></span>
+            <div class="text-sm space-y-2">
+              <div class="update-settings-row">
+                <div class="update-folder-info">
+                  <span class="font-medium">Update-Ordner:</span>
+                  <span id="update-folder-name" class="px-2 py-1 bg-gray-100 rounded">Keiner gewählt</span>
+                  <button id="select-update-folder" class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded">Ordner wählen</button>
+                  <button id="clear-update-folder" class="bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-1 rounded">Zurücksetzen</button>
+                  <span id="update-check-status" class="text-gray-500"></span>
+                </div>
+                <label class="update-toggle" title="Update-Hinweis im Hauptfenster anzeigen">
+                  <span class="sr-only">Update-Hinweis im Hauptfenster anzeigen</span>
+                  <input type="checkbox" id="setting-show-update-button">
+                  <span class="update-toggle-track"></span>
+                  <span class="update-toggle-thumb"></span>
+                </label>
               </div>
-              <label class="inline-flex items-center gap-2">
-                <input type="checkbox" id="setting-show-update-button" class="h-4 w-4">
-                <span>Update-Hinweis im Hauptfenster anzeigen</span>
-              </label>
             </div>
             <div id="updates-empty-state" class="text-sm text-gray-500">Keine Updates erforderlich.</div>
             <div class="updates-table-container overflow-x-auto">
@@ -375,10 +462,9 @@
                 <tbody id="updates-table-body"></tbody>
               </table>
             </div>
-            <div id="update-version-overview" class="border border-gray-200 rounded p-3 text-sm space-y-2">
+            <div id="update-version-overview" class="border border-gray-200 rounded p-3 text-sm space-y-3">
               <div class="font-semibold text-gray-700">Versionsübersicht</div>
-              <div id="update-version-html" class="text-gray-600"></div>
-              <ul id="update-version-modules" class="space-y-1 list-disc list-inside text-gray-600"></ul>
+              <div id="update-version-rows" class="version-overview-grid"></div>
             </div>
           </div>
         </div>
@@ -484,8 +570,7 @@ const updatesTableBody = document.getElementById('updates-table-body');
 const updatesEmptyState = document.getElementById('updates-empty-state');
 const updateCheckStatus = document.getElementById('update-check-status');
 const versionOverviewContainer = document.getElementById('update-version-overview');
-const versionOverviewHtmlEl = document.getElementById('update-version-html');
-const versionOverviewModulesEl = document.getElementById('update-version-modules');
+const versionOverviewRowsEl = document.getElementById('update-version-rows');
 // Settings inputs
 const inputAppBg = document.getElementById('setting-app-bg');
 const inputBorderColor = document.getElementById('setting-border-color');
@@ -521,6 +606,19 @@ const settingsNavButtons = document.querySelectorAll('.settings-nav button');
 // Remember the selected root folder across sessions
 const FS_HANDLE_KEY = 'rootDirHandle';
 const UPDATE_HANDLE_KEY = 'updateDirHandle';
+const UPDATE_HANDLE_NAME_KEY = 'updateDirDisplayName';
+
+const storedUpdateFolderName = (() => {
+  try {
+    return localStorage.getItem(UPDATE_HANDLE_NAME_KEY);
+  } catch (e) {
+    console.warn('Konnte Update-Ordnernamen nicht aus dem localStorage lesen', e);
+    return null;
+  }
+})();
+if (storedUpdateFolderName && updateFolderNameEl) {
+  updateFolderNameEl.textContent = storedUpdateFolderName;
+}
 
 function idbOpen() {
   return new Promise((res, rej) => {
@@ -598,6 +696,9 @@ async function tryRestoreUpdateHandle(){
     if (!ok) return false;
     updateDirHandle = h;
     if (updateFolderNameEl) updateFolderNameEl.textContent = h.name;
+    try { localStorage.setItem(UPDATE_HANDLE_NAME_KEY, h.name); } catch (e) {
+      console.warn('Konnte Update-Ordnernamen nicht speichern', e);
+    }
     return true;
   } catch (e) {
     console.warn('Restore update handle failed:', e);
@@ -613,7 +714,7 @@ function formatVersionDisplay(val) {
 
 function setUpdateStatusButton(state) {
   if (!updateStatusBtn) return;
-  updateStatusBtn.className = 'ml-auto text-sm px-3 py-1 rounded mr-2';
+  updateStatusBtn.className = 'text-sm px-3 py-1 rounded';
   updateStatusBtn.disabled = false;
 
   if (appSettings.showUpdateStatusButton === false) {
@@ -737,31 +838,59 @@ function renderUpdateList() {
 }
 
 function renderVersionOverview() {
-  if (!versionOverviewContainer || !versionOverviewHtmlEl || !versionOverviewModulesEl) return;
+  if (!versionOverviewContainer || !versionOverviewRowsEl) return;
   const htmlInfo = versionOverview?.html || { localVersion: null, updateVersion: null };
   const modulesInfo = Array.isArray(versionOverview?.modules) ? versionOverview.modules : [];
 
-  const localVersionText = formatVersionDisplay(htmlInfo.localVersion);
-  const updateVersionText = formatVersionDisplay(htmlInfo.updateVersion);
-  versionOverviewHtmlEl.textContent = `HTML (${HTML_FILE_NAME}): ${localVersionText} (Update: ${updateVersionText})`;
+  versionOverviewRowsEl.innerHTML = '';
 
-  versionOverviewModulesEl.innerHTML = '';
+  const headerName = document.createElement('div');
+  headerName.className = 'version-overview-header';
+  headerName.textContent = 'Datei';
+  const headerLocal = document.createElement('div');
+  headerLocal.className = 'version-overview-header text-right';
+  headerLocal.textContent = 'Aktuell';
+  const headerUpdate = document.createElement('div');
+  headerUpdate.className = 'version-overview-header text-right';
+  headerUpdate.textContent = 'Update';
+  versionOverviewRowsEl.append(headerName, headerLocal, headerUpdate);
+
+  const addRow = (label, localValue, updateValue) => {
+    const nameEl = document.createElement('div');
+    nameEl.className = 'version-overview-name';
+    nameEl.textContent = label;
+
+    const localEl = document.createElement('div');
+    localEl.className = 'version-overview-value';
+    localEl.textContent = localValue;
+
+    const updateEl = document.createElement('div');
+    updateEl.className = 'version-overview-value';
+    updateEl.textContent = updateValue;
+
+    versionOverviewRowsEl.append(nameEl, localEl, updateEl);
+  };
+
+  addRow(
+    `HTML (${HTML_FILE_NAME})`,
+    formatVersionDisplay(htmlInfo.localVersion),
+    formatVersionDisplay(htmlInfo.updateVersion)
+  );
+
   if (!modulesInfo.length) {
-    const li = document.createElement('li');
-    li.className = 'text-gray-500 list-none';
-    li.textContent = 'Keine Module gefunden.';
-    versionOverviewModulesEl.appendChild(li);
+    const emptyEl = document.createElement('div');
+    emptyEl.className = 'version-overview-empty';
+    emptyEl.textContent = 'Keine Module gefunden.';
+    versionOverviewRowsEl.appendChild(emptyEl);
     return;
   }
 
   modulesInfo.forEach(mod => {
-    const li = document.createElement('li');
-    const nameSpan = document.createElement('span');
-    nameSpan.className = 'font-medium text-gray-700';
-    nameSpan.textContent = mod.name;
-    li.appendChild(nameSpan);
-    li.appendChild(document.createTextNode(`: ${formatVersionDisplay(mod.localVersion)} (Update: ${formatVersionDisplay(mod.updateVersion)})`));
-    versionOverviewModulesEl.appendChild(li);
+    addRow(
+      mod.name,
+      formatVersionDisplay(mod.localVersion),
+      formatVersionDisplay(mod.updateVersion)
+    );
   });
 }
 
@@ -1128,6 +1257,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         const handle = await window.showDirectoryPicker();
         updateDirHandle = handle;
         if (updateFolderNameEl) updateFolderNameEl.textContent = handle.name;
+        try { localStorage.setItem(UPDATE_HANDLE_NAME_KEY, handle.name); } catch (e) {
+          console.warn('Konnte Update-Ordnernamen nicht speichern', e);
+        }
         await idbSet(UPDATE_HANDLE_KEY, handle);
         await runUpdateCheck();
       } catch (e) {
@@ -1143,6 +1275,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     clearUpdateFolderBtn.addEventListener('click', async () => {
       updateDirHandle = null;
       if (updateFolderNameEl) updateFolderNameEl.textContent = 'Keiner gewählt';
+      try { localStorage.removeItem(UPDATE_HANDLE_NAME_KEY); } catch (e) {
+        console.warn('Konnte Update-Ordnernamen nicht entfernen', e);
+      }
       await idbDel(UPDATE_HANDLE_KEY);
       pendingUpdates = [];
       versionOverview = {

--- a/V3-1-7.html
+++ b/V3-1-7.html
@@ -655,19 +655,26 @@ async function idbDel(key){
     tx.onerror = () => rej(tx.error);
   });
 }
-async function ensureRWPermission(handle){
+async function ensureRWPermission(handle, opts = {}){
   if (typeof handle?.queryPermission !== 'function') return true;
-  const q = await handle.queryPermission({ mode: 'readwrite' });
+  const mode = opts.mode || 'readwrite';
+  const q = await handle.queryPermission({ mode });
   if (q === 'granted') return true;
-  const r = await handle.requestPermission({ mode: 'readwrite' });
-  return r === 'granted';
+  if (opts.request === false) return false;
+  try {
+    const r = await handle.requestPermission({ mode });
+    return r === 'granted';
+  } catch (err) {
+    console.warn('requestPermission failed', err);
+    return false;
+  }
 }
 async function tryRestoreRootHandle(){
   if (!('showDirectoryPicker' in window)) return false;
   try {
     const h = await idbGet(FS_HANDLE_KEY);
     if (!h) return false;
-    const ok = await ensureRWPermission(h);
+    const ok = await ensureRWPermission(h, { request: false });
     if (!ok) return false;
 
     rootDirHandle = h;
@@ -692,7 +699,7 @@ async function tryRestoreUpdateHandle(){
   try {
     const h = await idbGet(UPDATE_HANDLE_KEY);
     if (!h) return false;
-    const ok = await ensureRWPermission(h);
+    const ok = await ensureRWPermission(h, { request: false });
     if (!ok) return false;
     updateDirHandle = h;
     if (updateFolderNameEl) updateFolderNameEl.textContent = h.name;

--- a/V3-1-7.html
+++ b/V3-1-7.html
@@ -123,11 +123,22 @@
       border-radius: 0.75rem;
       padding: 1rem;
       width: 95%;
-      max-width: 720px;
+      max-width: 860px;
+      max-height: 90vh;
       box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+      display: flex;
+      flex-direction: column;
 
       /* Ensure modal text colour does not inherit sidebar text colour */
       color: var(--body-text);
+    }
+    .settings-content {
+      overflow-y: auto;
+      flex: 1;
+    }
+    .updates-table-container {
+      max-height: 50vh;
+      overflow-y: auto;
     }
     .settings-nav button {
       border-radius: .5rem;
@@ -208,13 +219,14 @@
         <button data-section="modules">Module</button>
         <button data-section="updates">Updates</button>
       </div>
-      <!-- Allgemein section -->
-      <div id="section-general" class="settings-section active">
-        <div class="field-grid">
-          <div class="form-field">
-            <label>App Hintergrundfarbe</label>
-            <input type="color" id="setting-app-bg" value="#f3f4f6" class="w-full border rounded p-1">
-          </div>
+      <div class="settings-content mt-1 pr-1">
+        <!-- Allgemein section -->
+        <div id="section-general" class="settings-section active">
+          <div class="field-grid">
+            <div class="form-field">
+              <label>App Hintergrundfarbe</label>
+              <input type="color" id="setting-app-bg" value="#f3f4f6" class="w-full border rounded p-1">
+            </div>
           <div class="form-field">
             <label>Border Farbe</label>
             <input type="color" id="setting-border-color" value="#e5e7eb" class="w-full border rounded p-1">
@@ -242,13 +254,13 @@
           </div>
         </div>
       </div>
-      <!-- Topbar section -->
-      <div id="section-topbar" class="settings-section">
-        <div class="field-grid">
-          <div class="form-field">
-            <label>Topbar Hintergrundfarbe</label>
-            <input type="color" id="setting-topbar-bg" value="#ffffff" class="w-full border rounded p-1">
-          </div>
+        <!-- Topbar section -->
+        <div id="section-topbar" class="settings-section">
+          <div class="field-grid">
+            <div class="form-field">
+              <label>Topbar Hintergrundfarbe</label>
+              <input type="color" id="setting-topbar-bg" value="#ffffff" class="w-full border rounded p-1">
+            </div>
           <div class="form-field">
             <label>Aktiver Tab Hintergrund</label>
             <input type="color" id="setting-tab-active-bg" value="#2563eb" class="w-full border rounded p-1">
@@ -267,13 +279,13 @@
           </div>
         </div>
       </div>
-      <!-- Sidebar section -->
-      <div id="section-sidebar" class="settings-section">
-        <div class="field-grid">
-          <div class="form-field">
-            <label>Sidebar Hintergrundfarbe</label>
-            <input type="color" id="setting-sidebar-bg" value="#f3f4f6" class="w-full border rounded p-1">
-          </div>
+        <!-- Sidebar section -->
+        <div id="section-sidebar" class="settings-section">
+          <div class="field-grid">
+            <div class="form-field">
+              <label>Sidebar Hintergrundfarbe</label>
+              <input type="color" id="setting-sidebar-bg" value="#f3f4f6" class="w-full border rounded p-1">
+            </div>
           <div class="form-field">
             <label>Sidebar Textfarbe</label>
             <input type="color" id="setting-sidebar-text" value="#1f2937" class="w-full border rounded p-1">
@@ -297,13 +309,13 @@
           </div>
         </div>
       </div>
-      <!-- Modules section -->
-      <div id="section-modules" class="settings-section">
-        <div class="field-grid">
-          <div class="form-field">
-            <label>Modul Hintergrundfarbe</label>
-            <input type="color" id="setting-module-bg" value="#005983" class="w-full border rounded p-1">
-          </div>
+        <!-- Modules section -->
+        <div id="section-modules" class="settings-section">
+          <div class="field-grid">
+            <div class="form-field">
+              <label>Modul Hintergrundfarbe</label>
+              <input type="color" id="setting-module-bg" value="#005983" class="w-full border rounded p-1">
+            </div>
           <div class="form-field">
             <label>Modul Textfarbe</label>
             <input type="color" id="setting-text-color" value="#ffffff" class="w-full border rounded p-1">
@@ -334,27 +346,28 @@
           </div>
         </div>
       </div>
-      <div id="section-updates" class="settings-section">
-        <div class="space-y-4">
-          <div class="flex flex-wrap items-center gap-2 text-sm">
-            <span class="font-medium">Update-Ordner:</span>
-            <span id="update-folder-name" class="px-2 py-1 bg-gray-100 rounded">Keiner gewählt</span>
-            <button id="select-update-folder" class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded">Ordner wählen</button>
-            <button id="clear-update-folder" class="bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-1 rounded">Zurücksetzen</button>
-            <span id="update-check-status" class="text-gray-500"></span>
-          </div>
-          <div id="updates-empty-state" class="text-sm text-gray-500">Keine Updates erforderlich.</div>
-          <div class="overflow-x-auto">
-            <table class="min-w-full text-sm border border-gray-200 rounded" id="updates-table">
-              <thead class="bg-gray-100">
-                <tr>
-                  <th class="text-left px-3 py-2">Datei</th>
-                  <th class="text-left px-3 py-2">Änderungsdatum</th>
-                  <th class="text-right px-3 py-2">Aktion</th>
-                </tr>
-              </thead>
-              <tbody id="updates-table-body"></tbody>
-            </table>
+        <div id="section-updates" class="settings-section">
+          <div class="space-y-4">
+            <div class="flex flex-wrap items-center gap-2 text-sm">
+              <span class="font-medium">Update-Ordner:</span>
+              <span id="update-folder-name" class="px-2 py-1 bg-gray-100 rounded">Keiner gewählt</span>
+              <button id="select-update-folder" class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded">Ordner wählen</button>
+              <button id="clear-update-folder" class="bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-1 rounded">Zurücksetzen</button>
+              <span id="update-check-status" class="text-gray-500"></span>
+            </div>
+            <div id="updates-empty-state" class="text-sm text-gray-500">Keine Updates erforderlich.</div>
+            <div class="updates-table-container overflow-x-auto">
+              <table class="min-w-full text-sm border border-gray-200 rounded" id="updates-table">
+                <thead class="bg-gray-100">
+                  <tr>
+                    <th class="text-left px-3 py-2">Datei</th>
+                    <th class="text-left px-3 py-2">Änderungsdatum</th>
+                    <th class="text-right px-3 py-2">Aktion</th>
+                  </tr>
+                </thead>
+                <tbody id="updates-table-body"></tbody>
+              </table>
+            </div>
           </div>
         </div>
       </div>

--- a/V3-1-7.html
+++ b/V3-1-7.html
@@ -177,7 +177,8 @@
   <header id="top-bar" class="flex items-center gap-1 px-3 py-2 shadow" style="height:40px">
     <div id="tabs-container" class="flex items-center gap-1 flex-wrap"></div>
     <button id="add-tab" title="Neuen Tab erstellen" class="text-xl px-2 py-1 leading-none hover:opacity-80">➕</button>
-    <button id="select-root" class="ml-auto text-sm px-3 py-1 rounded">Ordner wählen</button>
+    <button id="update-status" class="ml-auto text-sm px-3 py-1 rounded mr-2 hidden">Update prüfen</button>
+    <button id="select-root" class="text-sm px-3 py-1 rounded">Ordner wählen</button>
     <button id="open-settings" title="Einstellungen" class="bg-gray-300 hover:bg-gray-400 text-gray-800 text-sm px-3 py-1 rounded ml-2">⚙️</button>
   </header>
   <div class="flex" style="height: calc(100% - 40px);">
@@ -205,6 +206,7 @@
         <button data-section="topbar">Topbar</button>
         <button data-section="sidebar">Sidebar</button>
         <button data-section="modules">Module</button>
+        <button data-section="updates">Updates</button>
       </div>
       <!-- Allgemein section -->
       <div id="section-general" class="settings-section active">
@@ -332,6 +334,30 @@
           </div>
         </div>
       </div>
+      <div id="section-updates" class="settings-section">
+        <div class="space-y-4">
+          <div class="flex flex-wrap items-center gap-2 text-sm">
+            <span class="font-medium">Update-Ordner:</span>
+            <span id="update-folder-name" class="px-2 py-1 bg-gray-100 rounded">Keiner gewählt</span>
+            <button id="select-update-folder" class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded">Ordner wählen</button>
+            <button id="clear-update-folder" class="bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-1 rounded">Zurücksetzen</button>
+            <span id="update-check-status" class="text-gray-500"></span>
+          </div>
+          <div id="updates-empty-state" class="text-sm text-gray-500">Keine Updates erforderlich.</div>
+          <div class="overflow-x-auto">
+            <table class="min-w-full text-sm border border-gray-200 rounded" id="updates-table">
+              <thead class="bg-gray-100">
+                <tr>
+                  <th class="text-left px-3 py-2">Datei</th>
+                  <th class="text-left px-3 py-2">Änderungsdatum</th>
+                  <th class="text-right px-3 py-2">Aktion</th>
+                </tr>
+              </thead>
+              <tbody id="updates-table-body"></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
       <div class="mt-4 flex justify-end gap-2">
         <button id="close-settings" class="bg-gray-300 hover:bg-gray-400 text-gray-800 text-sm px-3 py-1 rounded">Abbrechen</button>
         <button id="save-settings" class="bg-blue-600 hover:bg-blue-700 text-white text-sm px-3 py-1 rounded">Speichern</button>
@@ -375,6 +401,7 @@ const layoutFileName = 'layout.json';
 const settingsFileName = 'settings.json';
 const ACTIVE_TAB_STORAGE_KEY = 'modulesLayoutActiveTab';
 let rootDirHandle = null;
+let updateDirHandle = null;
 let modulesDirHandle = null;
 let liveModuleTemplates = [];
 let tabs = [];
@@ -383,6 +410,10 @@ let tabContextMenu = null;
 let tabsSortable = null;
 // Start with sidebar closed by default
 let isSidebarOpen = false;
+let pendingUpdates = [];
+let updateCheckInProgress = false;
+let originalSettings = null;
+let lastUpdateError = false;
 
 /* ==== UNIQUE IDs ==== */
 let usedInstanceIds = new Set();
@@ -409,11 +440,18 @@ const tabsContainer = document.getElementById('tabs-container');
 const addTabBtn = document.getElementById('add-tab');
 const sidebarEl = document.getElementById('sidebar');
 const sidebarToggle = document.getElementById('sidebar-toggle');
+const updateStatusBtn = document.getElementById('update-status');
 const rootBtn = document.getElementById('select-root');
 const settingsBtn = document.getElementById('open-settings');
 const settingsModal = document.getElementById('settings-modal');
 const closeSettingsBtn = document.getElementById('close-settings');
 const saveSettingsBtn = document.getElementById('save-settings');
+const updateFolderNameEl = document.getElementById('update-folder-name');
+const selectUpdateFolderBtn = document.getElementById('select-update-folder');
+const clearUpdateFolderBtn = document.getElementById('clear-update-folder');
+const updatesTableBody = document.getElementById('updates-table-body');
+const updatesEmptyState = document.getElementById('updates-empty-state');
+const updateCheckStatus = document.getElementById('update-check-status');
 // Settings inputs
 const inputAppBg = document.getElementById('setting-app-bg');
 const inputBorderColor = document.getElementById('setting-border-color');
@@ -447,6 +485,7 @@ const settingsNavButtons = document.querySelectorAll('.settings-nav button');
 
 // Remember the selected root folder across sessions
 const FS_HANDLE_KEY = 'rootDirHandle';
+const UPDATE_HANDLE_KEY = 'updateDirHandle';
 
 function idbOpen() {
   return new Promise((res, rej) => {
@@ -515,12 +554,257 @@ async function tryRestoreRootHandle(){
   }
 }
 
+async function tryRestoreUpdateHandle(){
+  if (!('showDirectoryPicker' in window)) return false;
+  try {
+    const h = await idbGet(UPDATE_HANDLE_KEY);
+    if (!h) return false;
+    const ok = await ensureRWPermission(h);
+    if (!ok) return false;
+    updateDirHandle = h;
+    if (updateFolderNameEl) updateFolderNameEl.textContent = h.name;
+    return true;
+  } catch (e) {
+    console.warn('Restore update handle failed:', e);
+    return false;
+  }
+}
+
+function formatTimestamp(ts) {
+  if (!ts) return '–';
+  try {
+    const date = new Date(ts);
+    if (Number.isNaN(date.getTime())) return '–';
+    return date.toLocaleString();
+  } catch {
+    return '–';
+  }
+}
+
+function setUpdateStatusButton(state) {
+  if (!updateStatusBtn) return;
+  updateStatusBtn.classList.remove('hidden');
+  updateStatusBtn.disabled = false;
+  updateStatusBtn.className = 'ml-auto text-sm px-3 py-1 rounded mr-2';
+  if (!rootDirHandle || !updateDirHandle) {
+    updateStatusBtn.textContent = 'Kein Update-Ordner';
+    updateStatusBtn.disabled = true;
+    updateStatusBtn.classList.add('bg-gray-300','text-gray-700','cursor-not-allowed');
+    return;
+  }
+  if (state === 'checking') {
+    updateStatusBtn.textContent = 'Prüfe…';
+    updateStatusBtn.disabled = true;
+    updateStatusBtn.classList.add('bg-gray-300','text-gray-700','cursor-wait');
+    return;
+  }
+  if (pendingUpdates.length) {
+    updateStatusBtn.textContent = 'Update available!';
+    updateStatusBtn.classList.add('bg-red-600','hover:bg-red-700','text-white');
+  } else {
+    updateStatusBtn.textContent = 'Up to date!';
+    updateStatusBtn.classList.add('bg-green-600','hover:bg-green-700','text-white');
+  }
+}
+
+function renderUpdateList() {
+  if (!updatesTableBody || !updatesEmptyState) return;
+  updatesTableBody.innerHTML = '';
+  if (!rootDirHandle || !updateDirHandle) {
+    updatesEmptyState.textContent = 'Bitte wählen Sie einen Root- und einen Update-Ordner.';
+    updatesEmptyState.classList.remove('hidden');
+    if (updateCheckStatus) updateCheckStatus.textContent = '';
+    setUpdateStatusButton();
+    return;
+  }
+  if (!pendingUpdates.length) {
+    updatesEmptyState.textContent = 'Keine Updates erforderlich.';
+    updatesEmptyState.classList.remove('hidden');
+    if (updateCheckStatus) updateCheckStatus.textContent = 'Keine Updates erforderlich.';
+    setUpdateStatusButton();
+    return;
+  }
+  updatesEmptyState.classList.add('hidden');
+  if (updateCheckStatus) {
+    updateCheckStatus.textContent = `${pendingUpdates.length} Update${pendingUpdates.length === 1 ? '' : 's'} verfügbar.`;
+  }
+  pendingUpdates.forEach((item, index) => {
+    const tr = document.createElement('tr');
+    tr.className = index % 2 ? 'bg-white' : 'bg-gray-50';
+    const tdPath = document.createElement('td');
+    tdPath.className = 'px-3 py-2 align-top';
+    tdPath.textContent = item.path;
+    const tdDates = document.createElement('td');
+    tdDates.className = 'px-3 py-2 align-top whitespace-nowrap';
+    tdDates.textContent = `${formatTimestamp(item.localLastModified)} → ${formatTimestamp(item.updateLastModified)}`;
+    const tdAction = document.createElement('td');
+    tdAction.className = 'px-3 py-2 text-right';
+    const btn = document.createElement('button');
+    btn.className = 'bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded';
+    btn.textContent = 'Aktualisieren';
+    btn.addEventListener('click', async () => {
+      btn.disabled = true;
+      btn.classList.add('opacity-60','cursor-wait');
+      try {
+        await applySingleUpdate(item);
+      } catch (err) {
+        console.error('Fehler beim Aktualisieren', err);
+        alert('Die Datei konnte nicht aktualisiert werden.');
+      } finally {
+        btn.disabled = false;
+        btn.classList.remove('opacity-60','cursor-wait');
+      }
+    });
+    tdAction.appendChild(btn);
+    tr.appendChild(tdPath);
+    tr.appendChild(tdDates);
+    tr.appendChild(tdAction);
+    updatesTableBody.appendChild(tr);
+  });
+  setUpdateStatusButton();
+}
+
+async function collectDirectoryDiffs(updateHandle, localHandle, prefix = '') {
+  const diffs = [];
+  for await (const entry of updateHandle.values()) {
+    const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.kind === 'directory') {
+      let localSub = null;
+      if (localHandle) {
+        try {
+          localSub = await localHandle.getDirectoryHandle(entry.name, { create: false });
+        } catch {
+          localSub = null;
+        }
+      }
+      const childDiffs = await collectDirectoryDiffs(entry, localSub, relPath);
+      diffs.push(...childDiffs);
+    } else if (entry.kind === 'file') {
+      const updateFile = await entry.getFile();
+      let localFileHandle = null;
+      let localFile = null;
+      if (localHandle) {
+        try {
+          localFileHandle = await localHandle.getFileHandle(entry.name, { create: false });
+          localFile = await localFileHandle.getFile();
+        } catch {
+          localFileHandle = null;
+          localFile = null;
+        }
+      }
+      const needsUpdate = !localFile || localFile.lastModified !== updateFile.lastModified || localFile.size !== updateFile.size;
+      if (needsUpdate) {
+        diffs.push({
+          path: relPath,
+          updateHandle: entry,
+          localHandle: localFileHandle,
+          localLastModified: localFile?.lastModified || null,
+          updateLastModified: updateFile.lastModified || null
+        });
+      }
+    }
+  }
+  return diffs;
+}
+
+async function ensureDirectoryChain(root, parts, { create = true } = {}) {
+  let current = root;
+  for (const part of parts) {
+    if (!part) continue;
+    current = await current.getDirectoryHandle(part, { create });
+  }
+  return current;
+}
+
+async function applySingleUpdate(item) {
+  if (!rootDirHandle || !updateDirHandle) return;
+  const segments = item.path.split('/');
+  const fileName = segments.pop();
+  const targetDir = await ensureDirectoryChain(rootDirHandle, segments, { create: true });
+  let sourceDir;
+  try {
+    sourceDir = await ensureDirectoryChain(updateDirHandle, segments, { create: false });
+  } catch (e) {
+    console.warn('Update-Verzeichnis nicht gefunden', e);
+    alert('Das Update-Verzeichnis für diese Datei konnte nicht gefunden werden.');
+    return;
+  }
+  let updateFileHandle;
+  try {
+    updateFileHandle = await sourceDir.getFileHandle(fileName, { create: false });
+  } catch (e) {
+    console.warn('Update-Datei nicht gefunden', e);
+    alert('Die Update-Datei konnte nicht gefunden werden.');
+    return;
+  }
+  const updateFile = await updateFileHandle.getFile();
+  const targetFileHandle = await targetDir.getFileHandle(fileName, { create: true });
+  const writable = await targetFileHandle.createWritable();
+  await writable.write(await updateFile.arrayBuffer());
+  await writable.close();
+  pendingUpdates = pendingUpdates.filter(diff => diff.path !== item.path);
+  renderUpdateList();
+}
+
+async function runUpdateCheck() {
+  lastUpdateError = false;
+  if (!rootDirHandle || !updateDirHandle) {
+    pendingUpdates = [];
+    renderUpdateList();
+    return;
+  }
+  if (updateCheckInProgress) return;
+  updateCheckInProgress = true;
+  setUpdateStatusButton('checking');
+  if (updateCheckStatus) updateCheckStatus.textContent = 'Prüfung läuft…';
+  try {
+    pendingUpdates = await collectDirectoryDiffs(updateDirHandle, rootDirHandle);
+  } catch (err) {
+    console.error('Update-Prüfung fehlgeschlagen', err);
+    pendingUpdates = [];
+    lastUpdateError = true;
+    if (updateCheckStatus) updateCheckStatus.textContent = 'Fehler bei der Prüfung.';
+  } finally {
+    updateCheckInProgress = false;
+    if (updateCheckStatus && !lastUpdateError) {
+      if (!pendingUpdates.length) {
+        updateCheckStatus.textContent = 'Letzte Prüfung abgeschlossen.';
+      } else {
+        updateCheckStatus.textContent = `${pendingUpdates.length} Update${pendingUpdates.length === 1 ? '' : 's'} verfügbar.`;
+      }
+    }
+    renderUpdateList();
+    if (lastUpdateError && updateCheckStatus) {
+      updateCheckStatus.textContent = 'Fehler bei der Prüfung.';
+    }
+  }
+}
+
+function activateSettingsSection(section) {
+  document.querySelectorAll('.settings-nav button').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.section === section);
+  });
+  document.querySelectorAll('.settings-section').forEach(sec => {
+    sec.classList.toggle('active', sec.id === `section-${section}`);
+  });
+}
+
+function openSettings(section = 'general') {
+  originalSettings = JSON.parse(JSON.stringify(appSettings));
+  populateInputsFromSettings();
+  settingsModal.classList.remove('hidden');
+  activateSettingsSection(section);
+}
+
 
 document.addEventListener('DOMContentLoaded', async () => {
   // Initialize sidebar collapsed state
   sidebarEl.classList.add('collapsed');
   // Trigger fade-in animation on initial load
   document.body.classList.add('fade-in');
+
+  setUpdateStatusButton();
+  renderUpdateList();
 
   // Sidebar toggle
   sidebarToggle.addEventListener('click', () => {
@@ -550,6 +834,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         // ensure grid state reflects current sidebar state
         updateModuleDraggable();
         updateGridDraggable();
+        await runUpdateCheck();
       } catch (e) {
         console.warn(e);
         alert('Ordnerauswahl abgebrochen oder nicht erlaubt.');
@@ -573,10 +858,50 @@ document.addEventListener('DOMContentLoaded', async () => {
         inp.value = null;
         updateModuleDraggable();
         updateGridDraggable();
+        pendingUpdates = [];
+        renderUpdateList();
       };
       inp.click();
     }
   });
+
+  if (selectUpdateFolderBtn) {
+    selectUpdateFolderBtn.addEventListener('click', async () => {
+      if (!('showDirectoryPicker' in window)) {
+        alert('Update-Ordner können nur mit einem kompatiblen Browser gewählt werden.');
+        return;
+      }
+      try {
+        const handle = await window.showDirectoryPicker();
+        updateDirHandle = handle;
+        if (updateFolderNameEl) updateFolderNameEl.textContent = handle.name;
+        await idbSet(UPDATE_HANDLE_KEY, handle);
+        await runUpdateCheck();
+      } catch (e) {
+        if (e?.name !== 'AbortError') {
+          console.warn('Update-Ordner Auswahl fehlgeschlagen', e);
+          alert('Der Update-Ordner konnte nicht gewählt werden.');
+        }
+      }
+    });
+  }
+
+  if (clearUpdateFolderBtn) {
+    clearUpdateFolderBtn.addEventListener('click', async () => {
+      updateDirHandle = null;
+      if (updateFolderNameEl) updateFolderNameEl.textContent = 'Keiner gewählt';
+      await idbDel(UPDATE_HANDLE_KEY);
+      pendingUpdates = [];
+      renderUpdateList();
+    });
+  }
+
+  if (updateStatusBtn) {
+    updateStatusBtn.addEventListener('click', () => {
+      if (updateStatusBtn.disabled) return;
+      openSettings('updates');
+    });
+  }
 
   // Add new tab
   addTabBtn.addEventListener('click', () => {
@@ -592,18 +917,17 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Settings open
   settingsBtn.addEventListener('click', () => {
-    originalSettings = JSON.parse(JSON.stringify(appSettings));
-    populateInputsFromSettings();
-    settingsModal.classList.remove('hidden');
+    openSettings('general');
   });
   // Settings cancel
   closeSettingsBtn.addEventListener('click', () => {
     settingsModal.classList.add('hidden');
-    if (typeof originalSettings !== 'undefined') {
+    if (typeof originalSettings !== 'undefined' && originalSettings !== null) {
       appSettings = { ...originalSettings };
       applySettings();
       renderTabs();
     }
+    originalSettings = null;
   });
   // Settings save
   saveSettingsBtn.addEventListener('click', async () => {
@@ -612,15 +936,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     await saveAppSettings();
     settingsModal.classList.add('hidden');
     renderTabs();
+    originalSettings = null;
   });
   // Settings nav
   settingsNavButtons.forEach(btn => {
     btn.addEventListener('click', () => {
-      settingsNavButtons.forEach(b => b.classList.remove('active'));
-      btn.classList.add('active');
-      const target = btn.dataset.section;
-      document.querySelectorAll('.settings-section').forEach(sec => sec.classList.remove('active'));
-      document.getElementById('section-' + target).classList.add('active');
+      activateSettingsSection(btn.dataset.section);
     });
   });
   // Live preview for colours
@@ -651,14 +972,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   updateGridAutoArrange();
 
   // --- Try to restore AFTER wiring handlers ---
-  const restored = await tryRestoreRootHandle();
-  if (!restored) {
-    // no-op; first-run already set up above
-  } else {
-    // Make sure grids reflect current sidebar state on restored sessions
+  const restoredRoot = await tryRestoreRootHandle();
+  await tryRestoreUpdateHandle();
+  if (restoredRoot) {
     updateModuleDraggable();
     updateGridDraggable();
   }
+  await runUpdateCheck();
 });
 
 /** Populate inputs from appSettings */

--- a/V3-1-7.html
+++ b/V3-1-7.html
@@ -1,3 +1,4 @@
+<!-- Version: 1.0 -->
 <!DOCTYPE html>
 <html lang="de">
 <head>
@@ -348,12 +349,18 @@
       </div>
         <div id="section-updates" class="settings-section">
           <div class="space-y-4">
-            <div class="flex flex-wrap items-center gap-2 text-sm">
-              <span class="font-medium">Update-Ordner:</span>
-              <span id="update-folder-name" class="px-2 py-1 bg-gray-100 rounded">Keiner gewählt</span>
-              <button id="select-update-folder" class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded">Ordner wählen</button>
-              <button id="clear-update-folder" class="bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-1 rounded">Zurücksetzen</button>
-              <span id="update-check-status" class="text-gray-500"></span>
+            <div class="flex flex-col gap-3 text-sm">
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="font-medium">Update-Ordner:</span>
+                <span id="update-folder-name" class="px-2 py-1 bg-gray-100 rounded">Keiner gewählt</span>
+                <button id="select-update-folder" class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded">Ordner wählen</button>
+                <button id="clear-update-folder" class="bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-1 rounded">Zurücksetzen</button>
+                <span id="update-check-status" class="text-gray-500"></span>
+              </div>
+              <label class="inline-flex items-center gap-2">
+                <input type="checkbox" id="setting-show-update-button" class="h-4 w-4">
+                <span>Update-Hinweis im Hauptfenster anzeigen</span>
+              </label>
             </div>
             <div id="updates-empty-state" class="text-sm text-gray-500">Keine Updates erforderlich.</div>
             <div class="updates-table-container overflow-x-auto">
@@ -361,12 +368,17 @@
                 <thead class="bg-gray-100">
                   <tr>
                     <th class="text-left px-3 py-2">Datei</th>
-                    <th class="text-left px-3 py-2">Änderungsdatum</th>
+                    <th class="text-left px-3 py-2">Version</th>
                     <th class="text-right px-3 py-2">Aktion</th>
                   </tr>
                 </thead>
                 <tbody id="updates-table-body"></tbody>
               </table>
+            </div>
+            <div id="update-version-overview" class="border border-gray-200 rounded p-3 text-sm space-y-2">
+              <div class="font-semibold text-gray-700">Versionsübersicht</div>
+              <div id="update-version-html" class="text-gray-600"></div>
+              <ul id="update-version-modules" class="space-y-1 list-disc list-inside text-gray-600"></ul>
             </div>
           </div>
         </div>
@@ -406,12 +418,14 @@ let appSettings = {
   moduleBorderColor: '#e5e7eb',
   sidebarModuleCardBg: '#ffffff',
   sidebarModuleCardText: '#1f2937',
-  sidebarModuleCardBorder: '#e5e7eb'
+  sidebarModuleCardBorder: '#e5e7eb',
+  showUpdateStatusButton: true
 };
 
 
 const layoutFileName = 'layout.json';
 const settingsFileName = 'settings.json';
+const HTML_FILE_NAME = 'V3-1-7.html';
 const ACTIVE_TAB_STORAGE_KEY = 'modulesLayoutActiveTab';
 let rootDirHandle = null;
 let updateDirHandle = null;
@@ -427,6 +441,10 @@ let pendingUpdates = [];
 let updateCheckInProgress = false;
 let originalSettings = null;
 let lastUpdateError = false;
+let versionOverview = {
+  html: { localVersion: null, updateVersion: null },
+  modules: []
+};
 
 /* ==== UNIQUE IDs ==== */
 let usedInstanceIds = new Set();
@@ -465,6 +483,9 @@ const clearUpdateFolderBtn = document.getElementById('clear-update-folder');
 const updatesTableBody = document.getElementById('updates-table-body');
 const updatesEmptyState = document.getElementById('updates-empty-state');
 const updateCheckStatus = document.getElementById('update-check-status');
+const versionOverviewContainer = document.getElementById('update-version-overview');
+const versionOverviewHtmlEl = document.getElementById('update-version-html');
+const versionOverviewModulesEl = document.getElementById('update-version-modules');
 // Settings inputs
 const inputAppBg = document.getElementById('setting-app-bg');
 const inputBorderColor = document.getElementById('setting-border-color');
@@ -492,6 +513,7 @@ const inputModuleBorderColor = document.getElementById('setting-module-border-co
 const inputSidebarModuleBg = document.getElementById('setting-sidebar-module-bg');
 const inputSidebarModuleText = document.getElementById('setting-sidebar-module-text');
 const inputSidebarModuleBorder = document.getElementById('setting-sidebar-module-border');
+const inputShowUpdateButton = document.getElementById('setting-show-update-button');
 
 // Navigation buttons for settings
 const settingsNavButtons = document.querySelectorAll('.settings-nav button');
@@ -583,34 +605,51 @@ async function tryRestoreUpdateHandle(){
   }
 }
 
-function formatTimestamp(ts) {
-  if (!ts) return '–';
-  try {
-    const date = new Date(ts);
-    if (Number.isNaN(date.getTime())) return '–';
-    return date.toLocaleString();
-  } catch {
-    return '–';
-  }
+function formatVersionDisplay(val) {
+  if (val === null || typeof val === 'undefined') return '–';
+  if (typeof val === 'string' && val.trim() === '') return '–';
+  return String(val);
 }
 
 function setUpdateStatusButton(state) {
   if (!updateStatusBtn) return;
-  updateStatusBtn.classList.remove('hidden');
-  updateStatusBtn.disabled = false;
   updateStatusBtn.className = 'ml-auto text-sm px-3 py-1 rounded mr-2';
-  if (!rootDirHandle || !updateDirHandle) {
+  updateStatusBtn.disabled = false;
+
+  if (appSettings.showUpdateStatusButton === false) {
+    updateStatusBtn.classList.add('hidden');
+    return;
+  }
+
+  updateStatusBtn.classList.remove('hidden');
+
+  if (!rootDirHandle) {
+    updateStatusBtn.textContent = 'Kein Arbeitsordner';
+    updateStatusBtn.disabled = true;
+    updateStatusBtn.classList.add('bg-gray-300','text-gray-700','cursor-not-allowed');
+    return;
+  }
+
+  if (!updateDirHandle) {
     updateStatusBtn.textContent = 'Kein Update-Ordner';
     updateStatusBtn.disabled = true;
     updateStatusBtn.classList.add('bg-gray-300','text-gray-700','cursor-not-allowed');
     return;
   }
+
   if (state === 'checking') {
     updateStatusBtn.textContent = 'Prüfe…';
     updateStatusBtn.disabled = true;
     updateStatusBtn.classList.add('bg-gray-300','text-gray-700','cursor-wait');
     return;
   }
+
+  if (lastUpdateError) {
+    updateStatusBtn.textContent = 'Prüfung fehlgeschlagen';
+    updateStatusBtn.classList.add('bg-yellow-500','hover:bg-yellow-600','text-white');
+    return;
+  }
+
   if (pendingUpdates.length) {
     updateStatusBtn.textContent = 'Update available!';
     updateStatusBtn.classList.add('bg-red-600','hover:bg-red-700','text-white');
@@ -623,38 +662,55 @@ function setUpdateStatusButton(state) {
 function renderUpdateList() {
   if (!updatesTableBody || !updatesEmptyState) return;
   updatesTableBody.innerHTML = '';
-  if (!rootDirHandle || !updateDirHandle) {
-    updatesEmptyState.textContent = 'Bitte wählen Sie einen Root- und einen Update-Ordner.';
+  if (!rootDirHandle) {
+    updatesEmptyState.textContent = 'Bitte wählen Sie einen Arbeitsordner.';
     updatesEmptyState.classList.remove('hidden');
     if (updateCheckStatus) updateCheckStatus.textContent = '';
+    renderVersionOverview();
     setUpdateStatusButton();
     return;
   }
+
+  if (!updateDirHandle) {
+    updatesEmptyState.textContent = 'Bitte wählen Sie einen Update-Ordner.';
+    updatesEmptyState.classList.remove('hidden');
+    if (updateCheckStatus) updateCheckStatus.textContent = '';
+    renderVersionOverview();
+    setUpdateStatusButton();
+    return;
+  }
+
   if (!pendingUpdates.length) {
     updatesEmptyState.textContent = 'Keine Updates erforderlich.';
     updatesEmptyState.classList.remove('hidden');
-    if (updateCheckStatus) updateCheckStatus.textContent = 'Keine Updates erforderlich.';
+    if (updateCheckStatus && !lastUpdateError) updateCheckStatus.textContent = 'Keine Updates erforderlich.';
+    renderVersionOverview();
     setUpdateStatusButton();
     return;
   }
+
   updatesEmptyState.classList.add('hidden');
-  if (updateCheckStatus) {
+  if (updateCheckStatus && !lastUpdateError) {
     updateCheckStatus.textContent = `${pendingUpdates.length} Update${pendingUpdates.length === 1 ? '' : 's'} verfügbar.`;
   }
+
   pendingUpdates.forEach((item, index) => {
     const tr = document.createElement('tr');
     tr.className = index % 2 ? 'bg-white' : 'bg-gray-50';
+
     const tdPath = document.createElement('td');
     tdPath.className = 'px-3 py-2 align-top';
-    tdPath.textContent = item.path;
-    const tdDates = document.createElement('td');
-    tdDates.className = 'px-3 py-2 align-top whitespace-nowrap';
-    tdDates.textContent = `${formatTimestamp(item.localLastModified)} → ${formatTimestamp(item.updateLastModified)}`;
+    tdPath.textContent = item.displayName || item.path;
+
+    const tdVersion = document.createElement('td');
+    tdVersion.className = 'px-3 py-2 align-top whitespace-nowrap';
+    tdVersion.textContent = `${formatVersionDisplay(item.currentVersion)} → ${formatVersionDisplay(item.newVersion)}`;
+
     const tdAction = document.createElement('td');
     tdAction.className = 'px-3 py-2 text-right';
     const btn = document.createElement('button');
     btn.className = 'bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded';
-    btn.textContent = 'Aktualisieren';
+    btn.textContent = 'sync';
     btn.addEventListener('click', async () => {
       btn.disabled = true;
       btn.classList.add('opacity-60','cursor-wait');
@@ -669,55 +725,197 @@ function renderUpdateList() {
       }
     });
     tdAction.appendChild(btn);
+
     tr.appendChild(tdPath);
-    tr.appendChild(tdDates);
+    tr.appendChild(tdVersion);
     tr.appendChild(tdAction);
     updatesTableBody.appendChild(tr);
   });
+
+  renderVersionOverview();
   setUpdateStatusButton();
 }
 
-async function collectDirectoryDiffs(updateHandle, localHandle, prefix = '') {
-  const diffs = [];
-  for await (const entry of updateHandle.values()) {
-    const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
-    if (entry.kind === 'directory') {
-      let localSub = null;
-      if (localHandle) {
+function renderVersionOverview() {
+  if (!versionOverviewContainer || !versionOverviewHtmlEl || !versionOverviewModulesEl) return;
+  const htmlInfo = versionOverview?.html || { localVersion: null, updateVersion: null };
+  const modulesInfo = Array.isArray(versionOverview?.modules) ? versionOverview.modules : [];
+
+  const localVersionText = formatVersionDisplay(htmlInfo.localVersion);
+  const updateVersionText = formatVersionDisplay(htmlInfo.updateVersion);
+  versionOverviewHtmlEl.textContent = `HTML (${HTML_FILE_NAME}): ${localVersionText} (Update: ${updateVersionText})`;
+
+  versionOverviewModulesEl.innerHTML = '';
+  if (!modulesInfo.length) {
+    const li = document.createElement('li');
+    li.className = 'text-gray-500 list-none';
+    li.textContent = 'Keine Module gefunden.';
+    versionOverviewModulesEl.appendChild(li);
+    return;
+  }
+
+  modulesInfo.forEach(mod => {
+    const li = document.createElement('li');
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'font-medium text-gray-700';
+    nameSpan.textContent = mod.name;
+    li.appendChild(nameSpan);
+    li.appendChild(document.createTextNode(`: ${formatVersionDisplay(mod.localVersion)} (Update: ${formatVersionDisplay(mod.updateVersion)})`));
+    versionOverviewModulesEl.appendChild(li);
+  });
+}
+
+async function readHtmlVersion(rootHandle) {
+  if (!rootHandle) return null;
+  try {
+    const fileHandle = await rootHandle.getFileHandle(HTML_FILE_NAME, { create: false });
+    const file = await fileHandle.getFile();
+    const text = await file.text();
+    const match = text.match(/<!--\s*Version:\s*([^>]+?)\s*-->/i);
+    const version = match ? match[1].trim() : null;
+    return { version, fileHandle };
+  } catch (e) {
+    if (e?.name !== 'NotFoundError') {
+      console.warn('HTML-Version konnte nicht gelesen werden', e);
+    }
+    return null;
+  }
+}
+
+async function gatherModulesMetadata(rootHandle) {
+  const modules = new Map();
+  if (!rootHandle) return { modules };
+  let modulesRoot;
+  try {
+    modulesRoot = await rootHandle.getDirectoryHandle('modules', { create: false });
+  } catch {
+    return { modules };
+  }
+
+  async function walk(dirHandle, relPath) {
+    const entries = [];
+    for await (const entry of dirHandle.values()) entries.push(entry);
+
+    let moduleData = null;
+    for (const entry of entries) {
+      if (entry.kind === 'file' && entry.name.endsWith('.json')) {
         try {
-          localSub = await localHandle.getDirectoryHandle(entry.name, { create: false });
-        } catch {
-          localSub = null;
+          const file = await entry.getFile();
+          const parsed = JSON.parse(await file.text());
+          if (parsed && typeof parsed === 'object') {
+            const moduleId = parsed.moduleId || parsed.id || parsed.name || relPath;
+            if (moduleId) {
+              moduleData = {
+                moduleId,
+                version: parsed.version ?? null,
+                name: parsed.name || moduleId,
+                relPath,
+                dirHandle,
+                raw: parsed
+              };
+              break;
+            }
+          }
+        } catch (e) {
+          console.warn('Modul-Metadaten konnten nicht gelesen werden', e);
         }
       }
-      const childDiffs = await collectDirectoryDiffs(entry, localSub, relPath);
-      diffs.push(...childDiffs);
-    } else if (entry.kind === 'file') {
-      const updateFile = await entry.getFile();
-      let localFileHandle = null;
-      let localFile = null;
-      if (localHandle) {
-        try {
-          localFileHandle = await localHandle.getFileHandle(entry.name, { create: false });
-          localFile = await localFileHandle.getFile();
-        } catch {
-          localFileHandle = null;
-          localFile = null;
-        }
-      }
-      const needsUpdate = !localFile || localFile.lastModified !== updateFile.lastModified || localFile.size !== updateFile.size;
-      if (needsUpdate) {
-        diffs.push({
-          path: relPath,
-          updateHandle: entry,
-          localHandle: localFileHandle,
-          localLastModified: localFile?.lastModified || null,
-          updateLastModified: updateFile.lastModified || null
-        });
+    }
+
+    if (moduleData) {
+      const versionValue = moduleData.version;
+      modules.set(moduleData.moduleId, {
+        moduleId: moduleData.moduleId,
+        version: versionValue === null || typeof versionValue === 'undefined' ? null : String(versionValue),
+        name: moduleData.name,
+        relPath,
+        dirHandle
+      });
+    }
+
+    for (const entry of entries) {
+      if (entry.kind === 'directory') {
+        const childRel = relPath ? `${relPath}/${entry.name}` : entry.name;
+        await walk(entry, childRel);
       }
     }
   }
-  return diffs;
+
+  await walk(modulesRoot, '');
+  return { modules };
+}
+
+async function collectVersionDiffs(updateHandle, localHandle) {
+  const overview = {
+    html: { localVersion: null, updateVersion: null },
+    modules: []
+  };
+  const diffs = [];
+
+  let localHtml = null;
+  let updateHtml = null;
+  try { localHtml = await readHtmlVersion(localHandle); } catch {}
+  try { updateHtml = await readHtmlVersion(updateHandle); } catch {}
+
+  if (localHtml) overview.html.localVersion = localHtml.version || null;
+  if (updateHtml) overview.html.updateVersion = updateHtml.version || null;
+
+  if (updateHtml && (updateHtml.version || !localHtml)) {
+    const localVersion = localHtml?.version || null;
+    if (localVersion !== updateHtml.version) {
+      diffs.push({
+        type: 'html',
+        path: HTML_FILE_NAME,
+        displayName: HTML_FILE_NAME,
+        currentVersion: localVersion,
+        newVersion: updateHtml.version || null,
+        sourcePath: HTML_FILE_NAME
+      });
+    }
+  }
+
+  const localModules = await gatherModulesMetadata(localHandle);
+  const updateModules = await gatherModulesMetadata(updateHandle);
+  const moduleIds = new Set([
+    ...Array.from(localModules.modules.keys()),
+    ...Array.from(updateModules.modules.keys())
+  ]);
+
+  const modulesList = [];
+  moduleIds.forEach(moduleId => {
+    const localMeta = localModules.modules.get(moduleId) || null;
+    const updateMeta = updateModules.modules.get(moduleId) || null;
+    const name = updateMeta?.name || localMeta?.name || moduleId;
+    const localVersion = localMeta?.version || null;
+    const updateVersion = updateMeta?.version || null;
+    modulesList.push({ moduleId, name, localVersion, updateVersion });
+
+    if (updateMeta && (localVersion !== updateVersion)) {
+      diffs.push({
+        type: 'module',
+        moduleId,
+        path: updateMeta.relPath ? `modules/${updateMeta.relPath}` : `modules/${moduleId}`,
+        displayName: name,
+        currentVersion: localVersion,
+        newVersion: updateVersion,
+        sourceRelPath: updateMeta.relPath,
+        targetRelPath: localMeta?.relPath || updateMeta.relPath,
+        updateDirHandle: updateMeta.dirHandle,
+        localDirHandle: localMeta?.dirHandle || null
+      });
+    }
+  });
+
+  modulesList.sort((a, b) => a.name.localeCompare(b.name, 'de', { sensitivity: 'base' }));
+  overview.modules = modulesList;
+
+  diffs.sort((a, b) => {
+    const nameA = (a.displayName || a.path || '').toLowerCase();
+    const nameB = (b.displayName || b.path || '').toLowerCase();
+    return nameA.localeCompare(nameB, 'de', { sensitivity: 'base' });
+  });
+
+  return { diffs, overview };
 }
 
 async function ensureDirectoryChain(root, parts, { create = true } = {}) {
@@ -730,66 +928,108 @@ async function ensureDirectoryChain(root, parts, { create = true } = {}) {
 }
 
 async function applySingleUpdate(item) {
-  if (!rootDirHandle || !updateDirHandle) return;
-  const segments = item.path.split('/');
-  const fileName = segments.pop();
-  const targetDir = await ensureDirectoryChain(rootDirHandle, segments, { create: true });
-  let sourceDir;
+  if (!rootDirHandle) return;
+  if (!item) return;
+
   try {
-    sourceDir = await ensureDirectoryChain(updateDirHandle, segments, { create: false });
-  } catch (e) {
-    console.warn('Update-Verzeichnis nicht gefunden', e);
-    alert('Das Update-Verzeichnis für diese Datei konnte nicht gefunden werden.');
-    return;
+    if (item.type === 'html') {
+      if (!updateDirHandle) throw new Error('Kein Update-Ordner vorhanden.');
+      const updateFileHandle = await updateDirHandle.getFileHandle(item.sourcePath || HTML_FILE_NAME, { create: false });
+      const updateFile = await updateFileHandle.getFile();
+      const targetFileHandle = await rootDirHandle.getFileHandle(HTML_FILE_NAME, { create: true });
+      const writable = await targetFileHandle.createWritable();
+      await writable.write(await updateFile.arrayBuffer());
+      await writable.close();
+    } else if (item.type === 'module') {
+      if (!updateDirHandle) throw new Error('Kein Update-Ordner vorhanden.');
+      const sourceSegments = ['modules', ...(item.sourceRelPath ? item.sourceRelPath.split('/') : [])];
+      const targetSegments = ['modules', ...(item.targetRelPath ? item.targetRelPath.split('/') : [])];
+      const sourceDir = await ensureDirectoryChain(updateDirHandle, sourceSegments, { create: false });
+      const targetDir = await ensureDirectoryChain(rootDirHandle, targetSegments, { create: true });
+      await copyDirectoryContents(sourceDir, targetDir);
+    } else if (item.sourcePath) {
+      if (!updateDirHandle) throw new Error('Kein Update-Ordner vorhanden.');
+      const segments = item.sourcePath.split('/');
+      const fileName = segments.pop();
+      const sourceDir = await ensureDirectoryChain(updateDirHandle, segments, { create: false });
+      const updateFileHandle = await sourceDir.getFileHandle(fileName, { create: false });
+      const targetDir = await ensureDirectoryChain(rootDirHandle, segments, { create: true });
+      const targetFileHandle = await targetDir.getFileHandle(fileName, { create: true });
+      const updateFile = await updateFileHandle.getFile();
+      const writable = await targetFileHandle.createWritable();
+      await writable.write(await updateFile.arrayBuffer());
+      await writable.close();
+    }
+  } catch (err) {
+    console.error('Fehler beim Synchronisieren', err);
+    throw err;
   }
-  let updateFileHandle;
-  try {
-    updateFileHandle = await sourceDir.getFileHandle(fileName, { create: false });
-  } catch (e) {
-    console.warn('Update-Datei nicht gefunden', e);
-    alert('Die Update-Datei konnte nicht gefunden werden.');
-    return;
+
+  await runUpdateCheck();
+}
+
+async function copyDirectoryContents(sourceDir, targetDir) {
+  for await (const entry of sourceDir.values()) {
+    if (entry.kind === 'file') {
+      const file = await entry.getFile();
+      const targetFileHandle = await targetDir.getFileHandle(entry.name, { create: true });
+      const writable = await targetFileHandle.createWritable();
+      await writable.write(await file.arrayBuffer());
+      await writable.close();
+    } else if (entry.kind === 'directory') {
+      const subTarget = await targetDir.getDirectoryHandle(entry.name, { create: true });
+      await copyDirectoryContents(entry, subTarget);
+    }
   }
-  const updateFile = await updateFileHandle.getFile();
-  const targetFileHandle = await targetDir.getFileHandle(fileName, { create: true });
-  const writable = await targetFileHandle.createWritable();
-  await writable.write(await updateFile.arrayBuffer());
-  await writable.close();
-  pendingUpdates = pendingUpdates.filter(diff => diff.path !== item.path);
-  renderUpdateList();
 }
 
 async function runUpdateCheck() {
+  if (updateCheckInProgress) return;
   lastUpdateError = false;
-  if (!rootDirHandle || !updateDirHandle) {
+
+  if (!rootDirHandle && !updateDirHandle) {
+    versionOverview = { html: { localVersion: null, updateVersion: null }, modules: [] };
     pendingUpdates = [];
+    if (updateCheckStatus) updateCheckStatus.textContent = '';
     renderUpdateList();
     return;
   }
-  if (updateCheckInProgress) return;
-  updateCheckInProgress = true;
-  setUpdateStatusButton('checking');
-  if (updateCheckStatus) updateCheckStatus.textContent = 'Prüfung läuft…';
+
+  if (rootDirHandle && updateDirHandle) {
+    updateCheckInProgress = true;
+    setUpdateStatusButton('checking');
+    if (updateCheckStatus) updateCheckStatus.textContent = 'Prüfung läuft…';
+  }
+
   try {
-    pendingUpdates = await collectDirectoryDiffs(updateDirHandle, rootDirHandle);
-  } catch (err) {
-    console.error('Update-Prüfung fehlgeschlagen', err);
-    pendingUpdates = [];
-    lastUpdateError = true;
-    if (updateCheckStatus) updateCheckStatus.textContent = 'Fehler bei der Prüfung.';
-  } finally {
-    updateCheckInProgress = false;
-    if (updateCheckStatus && !lastUpdateError) {
+    const result = await collectVersionDiffs(updateDirHandle, rootDirHandle);
+    versionOverview = result.overview;
+    pendingUpdates = rootDirHandle && updateDirHandle ? result.diffs : [];
+    lastUpdateError = false;
+    if (updateCheckStatus && rootDirHandle && updateDirHandle) {
       if (!pendingUpdates.length) {
         updateCheckStatus.textContent = 'Letzte Prüfung abgeschlossen.';
       } else {
         updateCheckStatus.textContent = `${pendingUpdates.length} Update${pendingUpdates.length === 1 ? '' : 's'} verfügbar.`;
       }
     }
-    renderUpdateList();
-    if (lastUpdateError && updateCheckStatus) {
+    if (updateCheckStatus && (!rootDirHandle || !updateDirHandle)) {
+      updateCheckStatus.textContent = '';
+    }
+  } catch (err) {
+    console.error('Update-Prüfung fehlgeschlagen', err);
+    pendingUpdates = [];
+    lastUpdateError = true;
+    if (updateCheckStatus && rootDirHandle && updateDirHandle) {
       updateCheckStatus.textContent = 'Fehler bei der Prüfung.';
     }
+    try {
+      const fallback = await collectVersionDiffs(null, rootDirHandle);
+      versionOverview = fallback.overview;
+    } catch {}
+  } finally {
+    updateCheckInProgress = false;
+    renderUpdateList();
   }
 }
 
@@ -905,7 +1145,12 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (updateFolderNameEl) updateFolderNameEl.textContent = 'Keiner gewählt';
       await idbDel(UPDATE_HANDLE_KEY);
       pendingUpdates = [];
+      versionOverview = {
+        html: { localVersion: versionOverview.html?.localVersion || null, updateVersion: null },
+        modules: versionOverview.modules.map(mod => ({ ...mod, updateVersion: null }))
+      };
       renderUpdateList();
+      await runUpdateCheck();
     });
   }
 
@@ -965,6 +1210,12 @@ document.addEventListener('DOMContentLoaded', async () => {
       renderTabs();
     });
   });
+  if (inputShowUpdateButton) {
+    inputShowUpdateButton.addEventListener('change', () => {
+      appSettings.showUpdateStatusButton = inputShowUpdateButton.checked;
+      setUpdateStatusButton();
+    });
+  }
   if (inputAutoArrange) {
     inputAutoArrange.addEventListener('change', () => {
       readInputsIntoSettings();
@@ -1022,6 +1273,7 @@ function populateInputsFromSettings() {
   if (inputSidebarModuleBg) inputSidebarModuleBg.value = toColor(appSettings.sidebarModuleCardBg, inputSidebarModuleBg.value);
   if (inputSidebarModuleText) inputSidebarModuleText.value = toColor(appSettings.sidebarModuleCardText, inputSidebarModuleText.value);
   if (inputSidebarModuleBorder) inputSidebarModuleBorder.value = toColor(appSettings.sidebarModuleCardBorder, inputSidebarModuleBorder.value);
+  if (inputShowUpdateButton) inputShowUpdateButton.checked = appSettings.showUpdateStatusButton !== false;
 }
 
 /** Read inputs into appSettings */
@@ -1052,6 +1304,7 @@ function readInputsIntoSettings() {
   appSettings.sidebarModuleCardBg = inputSidebarModuleBg.value;
   appSettings.sidebarModuleCardText = inputSidebarModuleText.value;
   appSettings.sidebarModuleCardBorder = inputSidebarModuleBorder.value;
+  if (inputShowUpdateButton) appSettings.showUpdateStatusButton = inputShowUpdateButton.checked;
 }
 
 /** Convert rgba to hex for colour inputs */
@@ -1097,6 +1350,7 @@ function applySettings() {
   document.documentElement.style.setProperty('--sidebar-module-card-border', appSettings.sidebarModuleCardBorder);
 
   updateGridAutoArrange();
+  setUpdateStatusButton();
 }
 
 /** Save settings to storage */

--- a/V3-1-7.html
+++ b/V3-1-7.html
@@ -699,7 +699,7 @@ async function tryRestoreUpdateHandle(){
   try {
     const h = await idbGet(UPDATE_HANDLE_KEY);
     if (!h) return false;
-    const ok = await ensureRWPermission(h, { request: false });
+    const ok = await ensureRWPermission(h, { request: false, mode: 'read' });
     if (!ok) return false;
     updateDirHandle = h;
     if (updateFolderNameEl) updateFolderNameEl.textContent = h.name;
@@ -1262,6 +1262,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
       try {
         const handle = await window.showDirectoryPicker();
+        const granted = await ensureRWPermission(handle, { mode: 'read' });
+        if (!granted) {
+          alert('Der Zugriff auf den Update-Ordner wurde nicht erlaubt.');
+          return;
+        }
         updateDirHandle = handle;
         if (updateFolderNameEl) updateFolderNameEl.textContent = handle.name;
         try { localStorage.setItem(UPDATE_HANDLE_NAME_KEY, handle.name); } catch (e) {

--- a/modules/Arbeitszeit/Arbeitszeit.json
+++ b/modules/Arbeitszeit/Arbeitszeit.json
@@ -1,6 +1,6 @@
 {
-  "name": "Arbeitszeit", 
-  "icon": "⏱️", 
+  "name": "Arbeitszeit",
+  "icon": "⏱️",
   "script": "renderArbeitszeit",
   "w": 3,
   "h": 4,
@@ -9,5 +9,7 @@
   "settings": {
     "regularHours": 7.5,
     "dressTime": 2
-  }
+  },
+  "moduleId": "Arbeitszeit",
+  "version": 1.0
 }

--- a/modules/Arbeitszeit/Arbeitszeit.json
+++ b/modules/Arbeitszeit/Arbeitszeit.json
@@ -11,5 +11,5 @@
     "dressTime": 2
   },
   "moduleId": "Arbeitszeit",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/Arbeitszeit/ArbeitszeitOverview.json
+++ b/modules/Arbeitszeit/ArbeitszeitOverview.json
@@ -5,5 +5,7 @@
   "w": 4,
   "h": 5,
   "minW": 3,
-  "minH": 3
+  "minH": 3,
+  "moduleId": "Arbeitszeit",
+  "version": 1.0
 }

--- a/modules/Arbeitszeit/ArbeitszeitOverview.json
+++ b/modules/Arbeitszeit/ArbeitszeitOverview.json
@@ -7,5 +7,5 @@
   "minW": 3,
   "minH": 3,
   "moduleId": "Arbeitszeit",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/AspenComments/AspenComments.json
+++ b/modules/AspenComments/AspenComments.json
@@ -9,5 +9,7 @@
   "h": 2,
   "settings": {
     "title": "Unit Comments"
-  }
+  },
+  "moduleId": "AspenComments",
+  "version": 1.0
 }

--- a/modules/AspenComments/AspenComments.json
+++ b/modules/AspenComments/AspenComments.json
@@ -11,5 +11,5 @@
     "title": "Unit Comments"
   },
   "moduleId": "AspenComments",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/AspenUnitList/AspenUnitList.json
+++ b/modules/AspenUnitList/AspenUnitList.json
@@ -10,5 +10,5 @@
     "title": "Aspen Board"
   },
   "moduleId": "AspenUnitList",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/AspenUnitList/AspenUnitList.json
+++ b/modules/AspenUnitList/AspenUnitList.json
@@ -8,5 +8,7 @@
   "h": 2,
   "settings": {
     "title": "Aspen Board"
-  }
+  },
+  "moduleId": "AspenUnitList",
+  "version": 1.0
 }

--- a/modules/DatenTest/DatenTest.json
+++ b/modules/DatenTest/DatenTest.json
@@ -9,5 +9,7 @@
   "settings": {
     "title": "Shared & Local Text",
     "moduleKey": "sharedLocal"
-  }
+  },
+  "moduleId": "DatenTest",
+  "version": 1.0
 }

--- a/modules/DatenTest/DatenTest.json
+++ b/modules/DatenTest/DatenTest.json
@@ -11,5 +11,5 @@
     "moduleKey": "sharedLocal"
   },
   "moduleId": "DatenTest",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/Denkhilfe/module.json
+++ b/modules/Denkhilfe/module.json
@@ -11,5 +11,5 @@
     "friction": 0.05
   },
   "moduleId": "Denkhilfe",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/Denkhilfe/module.json
+++ b/modules/Denkhilfe/module.json
@@ -9,5 +9,7 @@
   "settings": {
     "gravity": 0.5,
     "friction": 0.05
-  }
+  },
+  "moduleId": "Denkhilfe",
+  "version": 1.0
 }

--- a/modules/Filebrowser/FileBrowser.json
+++ b/modules/Filebrowser/FileBrowser.json
@@ -3,5 +3,5 @@
   "icon": "📁",
   "script": "renderFileBrowser",
   "moduleId": "Filebrowser",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/Filebrowser/FileBrowser.json
+++ b/modules/Filebrowser/FileBrowser.json
@@ -1,5 +1,7 @@
 {
   "name": "Dateiexplorer",
   "icon": "📁",
-  "script": "renderFileBrowser"
+  "script": "renderFileBrowser",
+  "moduleId": "Filebrowser",
+  "version": 1.0
 }

--- a/modules/FindingsSpreadsheet/FindingsSpreadsheet.json
+++ b/modules/FindingsSpreadsheet/FindingsSpreadsheet.json
@@ -7,5 +7,5 @@
   "w": 6,
   "h": 5,
   "moduleId": "FindingsSpreadsheet",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/FindingsSpreadsheet/FindingsSpreadsheet.json
+++ b/modules/FindingsSpreadsheet/FindingsSpreadsheet.json
@@ -5,5 +5,7 @@
   "minW": 3,
   "minH": 3,
   "w": 6,
-  "h": 5
+  "h": 5,
+  "moduleId": "FindingsSpreadsheet",
+  "version": 1.0
 }

--- a/modules/GeräteListe/GeräteListe.json
+++ b/modules/GeräteListe/GeräteListe.json
@@ -10,5 +10,5 @@
     "title": "Excel Unit Board"
   },
   "moduleId": "GeräteListe",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/GeräteListe/GeräteListe.json
+++ b/modules/GeräteListe/GeräteListe.json
@@ -8,5 +8,7 @@
   "h": 2,
   "settings": {
     "title": "Excel Unit Board"
-  }
+  },
+  "moduleId": "GeräteListe",
+  "version": 1.0
 }

--- a/modules/Gerätedaten/Gerätedaten.json
+++ b/modules/Gerätedaten/Gerätedaten.json
@@ -37,5 +37,5 @@
     ]
   },
   "moduleId": "Gerätedaten",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/Gerätedaten/Gerätedaten.json
+++ b/modules/Gerätedaten/Gerätedaten.json
@@ -9,11 +9,33 @@
   "settings": {
     "columns": 2,
     "fields": [
-      { "key": "meldung", "label": "Meldung", "enabled": true },
-      { "key": "auftrag", "label": "Auftrag", "enabled": true },
-      { "key": "part", "label": "P/N", "enabled": true },
-      { "key": "serial", "label": "S/N", "enabled": true },
-      { "key": "repairorder", "label": "Repairorder", "enabled": true }
+      {
+        "key": "meldung",
+        "label": "Meldung",
+        "enabled": true
+      },
+      {
+        "key": "auftrag",
+        "label": "Auftrag",
+        "enabled": true
+      },
+      {
+        "key": "part",
+        "label": "P/N",
+        "enabled": true
+      },
+      {
+        "key": "serial",
+        "label": "S/N",
+        "enabled": true
+      },
+      {
+        "key": "repairorder",
+        "label": "Repairorder",
+        "enabled": true
+      }
     ]
-  }
+  },
+  "moduleId": "Gerätedaten",
+  "version": 1.0
 }

--- a/modules/LinkButtons/LinkButtons.json
+++ b/modules/LinkButtons/LinkButtons.json
@@ -17,5 +17,5 @@
     ]
   },
   "moduleId": "LinkButtons",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/LinkButtons/LinkButtons.json
+++ b/modules/LinkButtons/LinkButtons.json
@@ -9,6 +9,13 @@
   "settings": {
     "leftTop": "Event",
     "leftBottom": "CMDS",
-    "rightLabels": ["ZIAUF3", "ZILLK", "ZIKV", "ZIQA"]
-  }
+    "rightLabels": [
+      "ZIAUF3",
+      "ZILLK",
+      "ZIKV",
+      "ZIQA"
+    ]
+  },
+  "moduleId": "LinkButtons",
+  "version": 1.0
 }

--- a/modules/LinkButtonsPlus/LinkButtonsPlus.json
+++ b/modules/LinkButtonsPlus/LinkButtonsPlus.json
@@ -19,5 +19,5 @@
     ]
   },
   "moduleId": "LinkButtonsPlus",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/LinkButtonsPlus/LinkButtonsPlus.json
+++ b/modules/LinkButtonsPlus/LinkButtonsPlus.json
@@ -9,6 +9,15 @@
   "settings": {
     "leftTop": "Event",
     "leftBottom": "CMDS",
-    "rightLabels": ["ZIAUF3", "ZILLK", "ZIKV", "ZIQA", "REPORT", "Workforce"]
-  }
+    "rightLabels": [
+      "ZIAUF3",
+      "ZILLK",
+      "ZIKV",
+      "ZIQA",
+      "REPORT",
+      "Workforce"
+    ]
+  },
+  "moduleId": "LinkButtonsPlus",
+  "version": 1.0
 }

--- a/modules/Luna/FileSystemAPI/FileSystemAPI.json
+++ b/modules/Luna/FileSystemAPI/FileSystemAPI.json
@@ -3,5 +3,5 @@
   "icon": "🗂️",
   "script": "renderFileSystemAPI",
   "moduleId": "FileSystemAPI",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/Luna/FileSystemAPI/FileSystemAPI.json
+++ b/modules/Luna/FileSystemAPI/FileSystemAPI.json
@@ -1,5 +1,7 @@
 {
-  "name": "File System API", 
+  "name": "File System API",
   "icon": "🗂️",
-  "script": "renderFileSystemAPI"
+  "script": "renderFileSystemAPI",
+  "moduleId": "FileSystemAPI",
+  "version": 1.0
 }

--- a/modules/Luna/RecentFiles/RecentFiles.json
+++ b/modules/Luna/RecentFiles/RecentFiles.json
@@ -7,5 +7,5 @@
   "w": 2,
   "h": 2,
   "moduleId": "RecentFiles",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/Luna/RecentFiles/RecentFiles.json
+++ b/modules/Luna/RecentFiles/RecentFiles.json
@@ -5,5 +5,7 @@
   "minW": 2,
   "minH": 2,
   "w": 2,
-  "h": 2
+  "h": 2,
+  "moduleId": "RecentFiles",
+  "version": 1.0
 }

--- a/modules/Luna/RecordViewer/module.json
+++ b/modules/Luna/RecordViewer/module.json
@@ -3,5 +3,7 @@
   "icon": "📄",
   "script": "renderRecordViewer",
   "minW": 4,
-  "minH": 4
+  "minH": 4,
+  "moduleId": "RecordViewer",
+  "version": 1.0
 }

--- a/modules/Luna/RecordViewer/module.json
+++ b/modules/Luna/RecordViewer/module.json
@@ -5,5 +5,5 @@
   "minW": 4,
   "minH": 4,
   "moduleId": "RecordViewer",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/Namensregeln/Namensregeln.json
+++ b/modules/Namensregeln/Namensregeln.json
@@ -8,5 +8,7 @@
   "h": 2,
   "settings": {
     "title": "Namensregeln"
-  }
+  },
+  "moduleId": "Namensregeln",
+  "version": 1.0
 }

--- a/modules/Namensregeln/Namensregeln.json
+++ b/modules/Namensregeln/Namensregeln.json
@@ -10,5 +10,5 @@
     "title": "Namensregeln"
   },
   "moduleId": "Namensregeln",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/SavedEvents/SavedEvents.json
+++ b/modules/SavedEvents/SavedEvents.json
@@ -9,5 +9,5 @@
   "maxW": 12,
   "maxH": 20,
   "moduleId": "SavedEvents",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/SavedEvents/SavedEvents.json
+++ b/modules/SavedEvents/SavedEvents.json
@@ -7,5 +7,7 @@
   "minW": 4,
   "minH": 5,
   "maxW": 12,
-  "maxH": 20
+  "maxH": 20,
+  "moduleId": "SavedEvents",
+  "version": 1.0
 }

--- a/modules/StandardFindings/StandardFindings.json
+++ b/modules/StandardFindings/StandardFindings.json
@@ -5,5 +5,7 @@
   "w": 4,
   "h": 6,
   "minW": 3,
-  "minH": 3
+  "minH": 3,
+  "moduleId": "StandardFindings",
+  "version": 1.0
 }

--- a/modules/StandardFindings/StandardFindings.json
+++ b/modules/StandardFindings/StandardFindings.json
@@ -7,5 +7,5 @@
   "minW": 3,
   "minH": 3,
   "moduleId": "StandardFindings",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/UnitList/unitList.json
+++ b/modules/UnitList/unitList.json
@@ -9,5 +9,7 @@
     "Unit 1",
     "Unit 2",
     "Unit 3"
-  ]
+  ],
+  "moduleId": "UnitList",
+  "version": 1.0
 }

--- a/modules/UnitList/unitList.json
+++ b/modules/UnitList/unitList.json
@@ -11,5 +11,5 @@
     "Unit 3"
   ],
   "moduleId": "UnitList",
-  "version": 1.0
+  "version": "1.0"
 }

--- a/modules/Workorder/Workorder.json
+++ b/modules/Workorder/Workorder.json
@@ -7,6 +7,7 @@
   "minW": 1,
   "minH": 5,
   "maxW": 10,
-  "maxH": 50
+  "maxH": 50,
+  "moduleId": "Workorder",
+  "version": 1.0
 }
-

--- a/modules/Workorder/Workorder.json
+++ b/modules/Workorder/Workorder.json
@@ -9,5 +9,5 @@
   "maxW": 10,
   "maxH": 50,
   "moduleId": "Workorder",
-  "version": 1.0
+  "version": "1.0"
 }


### PR DESCRIPTION
## Summary
- add an update status button and update tab in the settings modal
- allow selecting and clearing a persistent update folder for comparison
- run background file comparison to list outdated files and copy updates on demand

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1576f845c83218c0462d9178ed212