### PR TITLE
Improve NewStandardFindings parsing for flexible JSON

### DIFF
--- a/modules/NewStandardFindings/CHANGELOG.md
+++ b/modules/NewStandardFindings/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog – New Standard Findings
+
+Alle relevanten Änderungen ab Version 1.2.0 werden hier in Kurzform dokumentiert.
+
+## 1.2.0 – 2025-09-26
+### Highlights
+- Flexible Normalisierung für unterschiedliche JSON-Feldnamen (Findings, Actions, Routine, Mods usw.).
+- Verbesserte Parserlogik für verschachtelte bzw. alternative Strukturen sowie Dictionary-Erkennung.
+- Darstellung zusätzlicher Metadaten (Routine, Nonroutine, Parts, Times, Mods) direkt in Vorschau und Auswahl.
+- Automatisches Befüllen der Bereiche Routine, Nonroutine und Bestellliste aus den Finding-Daten.

--- a/modules/NewStandardFindings/CHANGELOG.md
+++ b/modules/NewStandardFindings/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Alle relevanten Änderungen ab Version 1.2.0 werden hier in Kurzform dokumentiert.
 
+## 1.2.2 – 2025-09-28
+### Fixed
+- Tief verschachtelte Findings-Strukturen werden erkannt; Parser durchsucht nun auch Routine-, Nonroutine-, Parts-, Times- und Mods-Objekte nach passenden Aliasfeldern.
+- Textaufbereitung formatiert Objektinhalte zeilenweise, sodass strukturierte Informationen aus alternativen JSON-Layouts lesbar bleiben.
+
 ## 1.2.1 – 2025-09-27
 ### Fixed
 - Partnummern werden jetzt beim Import aus Findings-JSON, Aspen-Board, Dictionary und lokalen Zuständen konsequent getrimmt und in Großbuchstaben überführt.

--- a/modules/NewStandardFindings/CHANGELOG.md
+++ b/modules/NewStandardFindings/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Alle relevanten Änderungen ab Version 1.2.0 werden hier in Kurzform dokumentiert.
 
+## 1.2.3 – 2025-09-29
+### Added
+- Schaltfläche zum Laden einer benutzerdefinierten Findings-Datei inklusive Speicherung des Dateipfads im Local Storage.
+- Anzeige des aktuell verwendeten Findings-Dateipfads in der Kontextübersicht.
+
 ## 1.2.2 – 2025-09-28
 ### Fixed
 - Tief verschachtelte Findings-Strukturen werden erkannt; Parser durchsucht nun auch Routine-, Nonroutine-, Parts-, Times- und Mods-Objekte nach passenden Aliasfeldern.

--- a/modules/NewStandardFindings/CHANGELOG.md
+++ b/modules/NewStandardFindings/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Alle relevanten Änderungen ab Version 1.2.0 werden hier in Kurzform dokumentiert.
 
+## 1.2.1 – 2025-09-27
+### Fixed
+- Partnummern werden jetzt beim Import aus Findings-JSON, Aspen-Board, Dictionary und lokalen Zuständen konsequent getrimmt und in Großbuchstaben überführt.
+- Historien- und Zustandseinträge migrieren automatisch auf die normalisierte Partnummer, sodass unterschiedliche Schreibweisen keine Duplikate mehr erzeugen.
+
 ## 1.2.0 – 2025-09-26
 ### Highlights
 - Flexible Normalisierung für unterschiedliche JSON-Feldnamen (Findings, Actions, Routine, Mods usw.).

--- a/modules/NewStandardFindings/Changelog.txt
+++ b/modules/NewStandardFindings/Changelog.txt
@@ -5,6 +5,11 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 
 ---
 
+## [1.2.1] – 2025-09-27
+### Fixed
+- Partnummern werden nun beim Einlesen aus JSON, Aspen-Board und Dictionary sowie beim Zugriff aus lokalen Zuständen konsistent getrimmt und in Großbuchstaben konvertiert.
+- Historieneinträge und gespeicherte Auswahlzustände übernehmen automatisch die normalisierte Partnummer, sodass mehrere Schreibweisen zusammengeführt werden.
+
 ## [1.2.0] – 2025-09-26
 ### Added
 - Erweiterte Normalisierung erkennt unterschiedliche Feldnamen (z. B. `Findings`, `Actions`, `Routine`, `Mods`) automatisch und mappt sie auf die internen Standardfelder.

--- a/modules/NewStandardFindings/Changelog.txt
+++ b/modules/NewStandardFindings/Changelog.txt
@@ -5,6 +5,15 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 
 ---
 
+## [1.2.0] – 2025-09-26
+### Added
+- Erweiterte Normalisierung erkennt unterschiedliche Feldnamen (z. B. `Findings`, `Actions`, `Routine`, `Mods`) automatisch und mappt sie auf die internen Standardfelder.
+- Unterstützung für verschachtelte und alternative JSON-Strukturen (Arrays, Objekte, `entries`, `findings` usw.), inklusive robuster Dictionary-Erkennung.
+- Anzeige zusätzlicher Metadaten pro Finding (Routine, Nonroutine, Parts, Times, Mods sowie weitere Zusatzfelder) direkt in den Auswahlhilfen.
+
+### Changed
+- Akzeptierte Findings füllen nun auch die Bereiche `Routine`, `Nonroutine` und ergänzen die Bestellliste automatisch mit hinterlegten Parts-Informationen.
+
 ## [1.1.0] – 2025-09-25
 ### Added
 - Unterstützung für neue Aspen-Feldnamen:

--- a/modules/NewStandardFindings/Changelog.txt
+++ b/modules/NewStandardFindings/Changelog.txt
@@ -5,6 +5,11 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 
 ---
 
+## [1.2.3] – 2025-09-29
+### Added
+- Neuer Button zum Auswählen einer Findings-JSON; die Auswahl wird eingelesen, gespeichert und der Dateipfad im Local Storage hinterlegt.
+- Kontextbereich zeigt nun den aktuell verwendeten Findings-Dateipfad an.
+
 ## [1.2.2] – 2025-09-28
 ### Fixed
 - Parser berücksichtigt nun auch verschachtelte JSON-Strukturen und findet Routine-, Nonroutine-, Parts-, Times- sowie Mods-Informationen über Aliasfelder.

--- a/modules/NewStandardFindings/Changelog.txt
+++ b/modules/NewStandardFindings/Changelog.txt
@@ -5,6 +5,11 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 
 ---
 
+## [1.2.2] – 2025-09-28
+### Fixed
+- Parser berücksichtigt nun auch verschachtelte JSON-Strukturen und findet Routine-, Nonroutine-, Parts-, Times- sowie Mods-Informationen über Aliasfelder.
+- Objektinhalte werden beim Import in Zeilenform konvertiert, damit strukturierte Daten aus alternativen Layouts gut lesbar bleiben.
+
 ## [1.2.1] – 2025-09-27
 ### Fixed
 - Partnummern werden nun beim Einlesen aus JSON, Aspen-Board und Dictionary sowie beim Zugriff aus lokalen Zuständen konsistent getrimmt und in Großbuchstaben konvertiert.

--- a/modules/NewStandardFindings/NewStandardFindings.js
+++ b/modules/NewStandardFindings/NewStandardFindings.js
@@ -110,6 +110,166 @@
 
   function clean(value){return value==null?'':String(value).trim();}
   function normalizeKey(value){return clean(value).toLowerCase();}
+  function canonicalKey(value){
+    return clean(value).toLowerCase().replace(/[^a-z0-9]+/g,'');
+  }
+
+  const ENTRY_COLLECTION_KEYS=new Set([
+    'entries','entry','findings','finding','items','item','records','record','list','liste',
+    'values','value','daten','data','standardfindings','standardfinding','library','collection','satz','saetze'
+  ].map(canonicalKey));
+
+  const DICTIONARY_KEYS=new Set([
+    'dictionary','lookup','meldungen','meldungsliste','mapping','map','dict','zuordnung','reference','lexikon',
+    'meldungszuordnung','meldungsmap','meldungsdictionary','meldungslookup','dictionaryentries','dictionaryentry'
+  ].map(canonicalKey));
+
+  const FIELD_ALIASES={
+    part:[
+      'part','partno','partnumber','partnr','pn','pnr','part_num','part_nummer','partnumber','part number',
+      'material','materialnr','materialnummer','materialno','material no','artikel','artikelnummer','artikel nr',
+      'component','componentno','componentnumber','partnummer'
+    ],
+    label:['label','title','name','beschreibung','desc','description','heading','überschrift','ueberschrift'],
+    finding:['finding','findings','findingtext','finding_text','befund','befunde','meldungstext','meldung','meldungen','befundtext'],
+    action:['action','actions','maßnahme','massnahme','maßnahmen','massnahmen','recommendation','empfehlung','correctiveaction','corrective_action','korrekturmaßnahme','korrektur'],
+    routine:['routine','routinetext','routine_text','routinefinding','routinefindingtext','routineaction','routinebeschreibung'],
+    nonroutine:['nonroutine','non_routine','nonroutinefinding','nonroutinefindingtext','nonroutineaction','nonroutinebeschreibung','non routine','non-routine'],
+    parts:['parts','ersatzteile','replacementparts','replacedparts','teile','bestellliste','spares','components'],
+    times:['times','time','zeit','zeiten','dauer','aufwand','arbeitszeit','stunden','timeestimate','time_estimate'],
+    mods:['mods','mod','modification','modifications','modifikation','modifikationen','changes','change','änderungen','aenderungen','modnotes']
+  };
+
+  const DICTIONARY_LABEL_ALIASES=[
+    'meldung','meldungsnr','meldungsnummer','meldungsno','meldungno','meldungsid','meldungid','meldungsname','melding',
+    'meldungscode','meldungstext','meldung_text','meldung title','key','label','finding','beschreibung','description','title','name'
+  ];
+  const DICTIONARY_PART_ALIASES=[
+    ...FIELD_ALIASES.part,
+    'value','wert','pn','pnr','partvalue','part_value','materialnummer','materialnr'
+  ];
+
+  const RESERVED_FIELDS=new Set(Object.values(FIELD_ALIASES).flat().map(canonicalKey));
+  RESERVED_FIELDS.add('finding');
+  RESERVED_FIELDS.add('label');
+  RESERVED_FIELDS.add('action');
+  RESERVED_FIELDS.add('part');
+
+  function buildFieldMap(raw){
+    const map={};
+    if(!raw||typeof raw!=='object') return map;
+    for(const [key,value] of Object.entries(raw)){
+      const canonical=canonicalKey(key);
+      if(!canonical) continue;
+      if(!(canonical in map)) map[canonical]=value;
+    }
+    return map;
+  }
+
+  function valueToText(value){
+    if(value==null) return '';
+    if(Array.isArray(value)){
+      const parts=value.map(v=>valueToText(v)).map(part=>clean(part)).filter(Boolean);
+      return Array.from(new Set(parts)).join('\n');
+    }
+    if(typeof value==='object'){
+      const candidates=['text','value','label','beschreibung','description','desc'];
+      for(const key of candidates){
+        if(Object.prototype.hasOwnProperty.call(value,key)){
+          const nested=valueToText(value[key]);
+          if(nested) return nested;
+        }
+      }
+      try{
+        const serialized=JSON.stringify(value);
+        return clean(serialized);
+      }catch{
+        return '';
+      }
+    }
+    return clean(value);
+  }
+
+  function formatMetaValue(value){
+    const text=clean(value);
+    if(!text) return '';
+    const parts=text.split(/\r?\n/).map(part=>clean(part)).filter(Boolean);
+    return parts.join(' · ');
+  }
+
+  function extractField(map,aliases){
+    if(!map) return '';
+    for(const alias of aliases){
+      const key=canonicalKey(alias);
+      if(key&&Object.prototype.hasOwnProperty.call(map,key)){
+        const text=valueToText(map[key]);
+        if(text) return text;
+      }
+    }
+    return '';
+  }
+
+  function hasField(map,aliases){
+    if(!map) return false;
+    for(const alias of aliases){
+      const key=canonicalKey(alias);
+      if(key&&Object.prototype.hasOwnProperty.call(map,key)){
+        const value=valueToText(map[key]);
+        if(value) return true;
+      }
+    }
+    return false;
+  }
+
+  function collectEntriesAndDictionary(parsed){
+    if(!parsed||typeof parsed!=='object') return {entries:[],dictionary:null};
+    const entries=[];
+    let dictionary=null;
+    const seenEntries=new Set();
+    const visited=new Set();
+
+    const visit=(value,isDictionary)=>{
+      if(value==null) return;
+      if(typeof value!=='object') return;
+      if(visited.has(value)) return;
+      visited.add(value);
+      if(Array.isArray(value)){
+        for(const item of value){
+          if(item&&typeof item==='object') visit(item,isDictionary);
+        }
+        return;
+      }
+      const map=buildFieldMap(value);
+      if(!isDictionary){
+        const hasPart=hasField(map,FIELD_ALIASES.part);
+        const hasContent=hasField(map,FIELD_ALIASES.finding)
+          ||hasField(map,FIELD_ALIASES.action)
+          ||hasField(map,FIELD_ALIASES.label);
+        if(hasPart&&hasContent&&!seenEntries.has(value)){
+          entries.push(value);
+          seenEntries.add(value);
+        }
+      }
+      for(const [key,val] of Object.entries(value)){
+        if(val==null) continue;
+        const canonical=canonicalKey(key);
+        if(!canonical) continue;
+        if(dictionary===null&&DICTIONARY_KEYS.has(canonical)){
+          dictionary=val;
+          visit(val,true);
+          continue;
+        }
+        if(ENTRY_COLLECTION_KEYS.has(canonical)){
+          visit(val,isDictionary);
+          continue;
+        }
+        visit(val,isDictionary);
+      }
+    };
+
+    visit(parsed,false);
+    return {entries,dictionary};
+  }
 
   function ensureData(){
     if(localStorage.getItem(DATA_KEY)) return Promise.resolve();
@@ -144,10 +304,24 @@
     if(Array.isArray(parsed)){
       entriesRaw=parsed;
     }else if(parsed&&typeof parsed==='object'){
-      if(Array.isArray(parsed.entries)) entriesRaw=parsed.entries;
-      else if(Array.isArray(parsed.findings)) entriesRaw=parsed.findings;
-      if(parsed.dictionary) dictionaryRaw=parsed.dictionary;
-      else if(parsed.meldungen) dictionaryRaw=parsed.meldungen;
+      const extracted=collectEntriesAndDictionary(parsed);
+      if(extracted.entries&&extracted.entries.length) entriesRaw=extracted.entries;
+      if(extracted.dictionary) dictionaryRaw=extracted.dictionary;
+      if(!entriesRaw.length){
+        if(Array.isArray(parsed.entries)) entriesRaw=parsed.entries;
+        else if(Array.isArray(parsed.findings)) entriesRaw=parsed.findings;
+        else if(Array.isArray(parsed.items)) entriesRaw=parsed.items;
+        else if(Array.isArray(parsed.records)) entriesRaw=parsed.records;
+      }
+      if(dictionaryRaw==null){
+        if(parsed.dictionary) dictionaryRaw=parsed.dictionary;
+        else if(parsed.meldungen) dictionaryRaw=parsed.meldungen;
+        else if(parsed.lookup) dictionaryRaw=parsed.lookup;
+      }
+    }
+    if(!Array.isArray(entriesRaw)){
+      if(entriesRaw&&typeof entriesRaw==='object') entriesRaw=[entriesRaw];
+      else entriesRaw=[];
     }
     const normalizedEntries=normalizeEntries(entriesRaw);
     const dictionary=normalizeDictionary(dictionaryRaw);
@@ -174,25 +348,76 @@
     const counts=new Map();
     const result=[];
     for(const raw of list){
-      const part=clean(raw&&raw.part);
-      const label=clean(raw&&raw.label);
-      const finding=clean(raw&&raw.finding);
-      const action=clean(raw&&raw.action);
-      if(!part&& !finding && !action) continue;
-      const baseKey=[part,label,finding,action].join('||');
+      if(!raw||typeof raw!=='object') continue;
+      const map=buildFieldMap(raw);
+      const part=clean(extractField(map,FIELD_ALIASES.part));
+      const label=clean(extractField(map,FIELD_ALIASES.label));
+      const finding=clean(extractField(map,FIELD_ALIASES.finding));
+      const action=clean(extractField(map,FIELD_ALIASES.action));
+      const routine=clean(extractField(map,FIELD_ALIASES.routine));
+      const nonroutine=clean(extractField(map,FIELD_ALIASES.nonroutine));
+      const partsText=clean(extractField(map,FIELD_ALIASES.parts));
+      const times=clean(extractField(map,FIELD_ALIASES.times));
+      const mods=clean(extractField(map,FIELD_ALIASES.mods));
+      if(!part&&( !finding && !action && !label)) continue;
+      if(!part) continue;
+      const extras=[];
+      const extrasKeyParts=[];
+      const extrasSeen=new Set();
+      for(const [rawKey,value] of Object.entries(raw)){
+        const canonical=canonicalKey(rawKey);
+        if(!canonical) continue;
+        if(RESERVED_FIELDS.has(canonical)) continue;
+        if(extrasSeen.has(canonical)) continue;
+        const text=valueToText(value);
+        if(!text) continue;
+        extrasSeen.add(canonical);
+        const displayLabel=clean(rawKey)||rawKey;
+        const valueLower=text.toLowerCase();
+        extras.push({
+          key:rawKey,
+          label:displayLabel,
+          value:text,
+          valueLower
+        });
+        extrasKeyParts.push(text);
+      }
+      extras.sort((a,b)=>a.label.localeCompare(b.label,'de',{sensitivity:'base'}));
+      const baseKeyParts=[part,label,finding,action,routine,nonroutine,partsText,times,mods];
+      if(extrasKeyParts.length) baseKeyParts.push(...extrasKeyParts);
+      const baseKey=baseKeyParts.join('||');
       const count=counts.get(baseKey)||0;
       counts.set(baseKey,count+1);
       const key=count?`${baseKey}__${count}`:baseKey;
-      if(!part) continue;
+      const labelValue=label||'';
+      const findingValue=finding||'';
+      const actionValue=action||'';
+      const routineValue=routine||'';
+      const nonroutineValue=nonroutine||'';
+      const partsValue=partsText||'';
+      const timesValue=times||'';
+      const modsValue=mods||'';
       result.push({
         key,
         part,
-        label,
-        finding,
-        action,
-        labelLower:label.toLowerCase(),
-        findingLower:finding.toLowerCase(),
-        actionLower:action.toLowerCase()
+        label:labelValue,
+        finding:findingValue,
+        action:actionValue,
+        routine:routineValue,
+        nonroutine:nonroutineValue,
+        parts:partsValue,
+        times:timesValue,
+        mods:modsValue,
+        additional:extras,
+        additionalLower:extras.map(item=>item.valueLower),
+        labelLower:labelValue.toLowerCase(),
+        findingLower:findingValue.toLowerCase(),
+        actionLower:actionValue.toLowerCase(),
+        routineLower:routineValue.toLowerCase(),
+        nonroutineLower:nonroutineValue.toLowerCase(),
+        partsLower:partsValue.toLowerCase(),
+        timesLower:timesValue.toLowerCase(),
+        modsLower:modsValue.toLowerCase()
       });
     }
     return result;
@@ -202,15 +427,27 @@
     const map=new Map();
     if(Array.isArray(input)){
       for(const entry of input){
-        const meld=clean(entry&& (entry.meldung||entry.key||entry.label));
-        const part=clean(entry&& (entry.part||entry.partNo||entry.partNumber||entry.value));
+        if(!entry) continue;
+        if(typeof entry==='string'||typeof entry==='number'){continue;}
+        if(typeof entry!=='object') continue;
+        const mapEntry=buildFieldMap(entry);
+        const labelAliases=[...DICTIONARY_LABEL_ALIASES,...FIELD_ALIASES.finding,...FIELD_ALIASES.label];
+        const meldRaw=extractField(mapEntry,labelAliases) || valueToText(entry.meldung) || valueToText(entry.key);
+        const partRaw=extractField(mapEntry,DICTIONARY_PART_ALIASES) || valueToText(entry.value);
+        const meld=clean(meldRaw);
+        const part=clean(partRaw);
         if(!meld||!part) continue;
         map.set(normalizeKey(meld),part);
       }
     }else if(input&&typeof input==='object'){
       for(const [meldung,partVal] of Object.entries(input)){
         const meld=clean(meldung);
-        const part=clean(partVal);
+        let part='';
+        if(partVal&&typeof partVal==='object'){
+          part=clean(valueToText(partVal));
+        }else{
+          part=clean(partVal);
+        }
         if(!meld||!part) continue;
         map.set(normalizeKey(meld),part);
       }
@@ -981,6 +1218,48 @@
       root.append(contextSection,inputSection,outputsSection);
     }
 
+    renderEntryMeta(target,entry,options){
+      if(!target) return;
+      const config={
+        showFinding:false,
+        showLabel:true,
+        showAction:true,
+        showAdditional:true,
+        ...options
+      };
+      target.innerHTML='';
+      if(!entry){
+        target.style.display='none';
+        return;
+      }
+      const addLine=(label,value)=>{
+        const text=formatMetaValue(value);
+        if(!text) return;
+        const row=document.createElement('div');
+        const strong=document.createElement('strong');
+        strong.textContent=`${label}:`;
+        row.append(strong,document.createTextNode(` ${text}`));
+        target.appendChild(row);
+      };
+      if(config.showFinding&&entry.finding) addLine('Finding',entry.finding);
+      if(config.showLabel&&entry.label) addLine('Label',entry.label);
+      if(config.showAction&&entry.action) addLine('Action',entry.action);
+      if(entry.routine) addLine('Routine',entry.routine);
+      if(entry.nonroutine) addLine('Nonroutine',entry.nonroutine);
+      if(entry.parts) addLine('Parts',entry.parts);
+      if(entry.times) addLine('Times',entry.times);
+      if(entry.mods) addLine('Mods',entry.mods);
+      if(config.showAdditional!==false&&Array.isArray(entry.additional)){
+        for(const extra of entry.additional){
+          const label=clean(extra.label||extra.key);
+          const value=clean(extra.value);
+          if(!label||!value) continue;
+          addLine(label,value);
+        }
+      }
+      target.style.display=target.childElementCount?'flex':'none';
+    }
+
     addInputRow(prefillEntry,focusNext){
       const row=document.createElement('div');
       row.className='nsf-input-row';
@@ -1016,23 +1295,7 @@
         entry:null
       };
       const showHelper=entry=>{
-        if(entry&&(entry.label||entry.action)){
-          helper.innerHTML='';
-          if(entry.label){
-            const labelLine=document.createElement('div');
-            labelLine.textContent=`Label: ${entry.label}`;
-            helper.appendChild(labelLine);
-          }
-          if(entry.action){
-            const actionLine=document.createElement('div');
-            actionLine.textContent=`Action: ${entry.action}`;
-            helper.appendChild(actionLine);
-          }
-          helper.style.display='flex';
-        }else{
-          helper.innerHTML='';
-          helper.style.display='none';
-        }
+        this.renderEntryMeta(helper,entry,{showFinding:true});
       };
       const closeSuggestions=()=>{
         row.classList.remove('show-suggestions');
@@ -1049,6 +1312,12 @@
           if(entry.findingLower.includes(query)) return true;
           if(entry.labelLower.includes(query)) return true;
           if(entry.actionLower.includes(query)) return true;
+          if(entry.routineLower&&entry.routineLower.includes(query)) return true;
+          if(entry.nonroutineLower&&entry.nonroutineLower.includes(query)) return true;
+          if(entry.partsLower&&entry.partsLower.includes(query)) return true;
+          if(entry.timesLower&&entry.timesLower.includes(query)) return true;
+          if(entry.modsLower&&entry.modsLower.includes(query)) return true;
+          if(entry.additionalLower&&entry.additionalLower.some(val=>val&&val.includes(query))) return true;
           return false;
         }).slice(0,20);
         state.suggestionsList=matches;
@@ -1171,29 +1440,16 @@
       state.suggestionsList=[];
       state.highlightIndex=-1;
       if(state.helper){
-        state.helper.innerHTML='';
-        state.helper.style.display='none';
+        this.renderEntryMeta(state.helper,null,{showFinding:true});
       }
-      state.meta.innerHTML='';
-      if(entry.label){
-        const labelRow=document.createElement('div');
-        const strong=document.createElement('strong');
-        strong.textContent='Label:';
-        labelRow.append(strong,document.createTextNode(' '+entry.label));
-        state.meta.appendChild(labelRow);
-      }
-      if(entry.action){
-        const actionRow=document.createElement('div');
-        const strong=document.createElement('strong');
-        strong.textContent='Action:';
-        actionRow.append(strong,document.createTextNode(' '+entry.action));
-        state.meta.appendChild(actionRow);
-      }
-      state.meta.style.display=state.meta.childElementCount?'flex':'none';
+      this.renderEntryMeta(state.meta,entry,{showFinding:true});
       if(opts.addOutputs!==false){
         this.appendOutput('findings',entry.finding);
         this.appendOutput('actions',entry.action);
         this.appendOutput('parts',entry.part);
+        if(entry.routine) this.appendOutput('routine',entry.routine);
+        if(entry.nonroutine) this.appendOutput('nonroutine',entry.nonroutine);
+        if(entry.parts) this.appendOutput('parts',entry.parts);
       }
       if(opts.persist!==false){
         this.addSelection(entry);
@@ -1255,6 +1511,9 @@
       this.removeOutput('findings',entry.finding);
       this.removeOutput('actions',entry.action);
       this.removeOutput('parts',entry.part);
+      this.removeOutput('routine',entry.routine);
+      this.removeOutput('nonroutine',entry.nonroutine);
+      this.removeOutput('parts',entry.parts);
     }
 
     removeOutput(field,text){

--- a/modules/NewStandardFindings/NewStandardFindings.json
+++ b/modules/NewStandardFindings/NewStandardFindings.json
@@ -7,5 +7,5 @@
   "minW": 2,
   "minH": 12,
   "moduleId": "NewStandardFindings",
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/modules/NewStandardFindings/NewStandardFindings.json
+++ b/modules/NewStandardFindings/NewStandardFindings.json
@@ -7,5 +7,5 @@
   "minW": 2,
   "minH": 12,
   "moduleId": "NewStandardFindings",
-  "version": "1.2.1"
+  "version": "1.2.2"
 }

--- a/modules/NewStandardFindings/NewStandardFindings.json
+++ b/modules/NewStandardFindings/NewStandardFindings.json
@@ -7,5 +7,5 @@
   "minW": 2,
   "minH": 12,
   "moduleId": "NewStandardFindings",
-  "version": "1.2.0"
+  "version": "1.2.1"
 }

--- a/modules/NewStandardFindings/NewStandardFindings.json
+++ b/modules/NewStandardFindings/NewStandardFindings.json
@@ -7,5 +7,5 @@
   "minW": 2,
   "minH": 12,
   "moduleId": "NewStandardFindings",
-  "version": "1.2.2"
+  "version": "1.2.3"
 }


### PR DESCRIPTION
## Summary
- extend the New Standard Findings parser to normalize multiple field aliases and nested data structures
- surface routine, nonroutine, parts, times and mods metadata in the UI and auto-fill the corresponding outputs
- bump the module version to 1.2.0 and document the update in changelog files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d50688aacc832dbdf0b1ada5bc5795