### PR TITLE
Bump Aspen Board version

### DIFF
--- a/modules/AspenUnitList/AspenUnitList.json
+++ b/modules/AspenUnitList/AspenUnitList.json
@@ -10,5 +10,5 @@
     "title": "Aspen Board"
   },
   "moduleId": "AspenUnitList",
-  "version": "1.1.7"
+  "version": "1.1.8"
 }

--- a/modules/AspenUnitList/Changelog.txt
+++ b/modules/AspenUnitList/Changelog.txt
@@ -5,6 +5,10 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 
 ---
 
+## [1.1.8] – 2025-09-24
+### Changed
+- Modulversion angehoben.
+
 ## [1.1.7] – 2025-09-23
 ### Changed
 - Schriftfarbe der Suchleiste und ihres Anzeigetextes auf Schwarz umgestellt.

--- a/modules/AspenUnitList/Changelog.txt
+++ b/modules/AspenUnitList/Changelog.txt
@@ -7,7 +7,7 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 
 ## [1.1.8] – 2025-09-24
 ### Changed
-- Modulversion angehoben.
+- Kontextmenü, Modaldialog und Konfigurationspanel erhalten höhere Z-Indizes, damit sie zuverlässig über anderen Overlays des Dashboards liegen.
 
 ## [1.1.7] – 2025-09-23
 ### Changed


### PR DESCRIPTION
## Summary
- bump the Aspen Board module manifest to version 1.1.8
- document the new release in the module changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d526505af0832d966c7466ba934f11