### PR TITLE
Clarify module changelog entries for latest release

### DIFF
--- a/ShopguideChangelog.txt
+++ b/ShopguideChangelog.txt
@@ -5,6 +5,13 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 
 ---
 
+## [3.6.5] – 2025-09-29
+### Added
+- New Standard Findings auf Version 1.2.3 angehoben; Dateiauswahl-Button und Kontextinfo zeigen nun den gespeicherten Findings-Pfad.
+
+### Changed
+- Shopguide Findings Editor auf Version 1.2.0 aktualisiert; Partnummern lassen sich in flexiblen Listen erfassen und erscheinen als Untertitel samt Export- und Suchunterstützung.
+
 ## [3.6.4] – 2025-09-27
 ### Changed
 - Shopguide Findings Editor auf Version 1.1.2 aktualisiert; Bestelltext (PNText) sowie bis zu sechs Teilenummer-/Mengen-Paare werden nun getrennt erfasst, durchsucht und im Originalformat gespeichert.

--- a/ShopguideV3.html
+++ b/ShopguideV3.html
@@ -1,4 +1,4 @@
-<!-- Version: 3.5.0 -->
+<!-- Version: 3.6.5 -->
 <!DOCTYPE html>
 <html lang="de">
 <head>

--- a/modules/NewStandardFindings/CHANGELOG.md
+++ b/modules/NewStandardFindings/CHANGELOG.md
@@ -6,6 +6,10 @@ Alle relevanten Änderungen ab Version 1.2.0 werden hier in Kurzform dokumentier
 ### Added
 - Schaltfläche zum Laden einer benutzerdefinierten Findings-Datei inklusive Speicherung des Dateipfads im Local Storage.
 - Anzeige des aktuell verwendeten Findings-Dateipfads in der Kontextübersicht.
+- Schnellaktionen im Kopfbereich öffnen direkt die zuletzt verwendeten Findings- oder Aspen-Dateien.
+
+### Changed
+- Ausgewählte Findings-Dateien werden beim Modulstart geladen und zwischen Browser-Tabs über Storage-Events synchron gehalten.
 
 ## 1.2.2 – 2025-09-28
 ### Fixed

--- a/modules/NewStandardFindings/Changelog.txt
+++ b/modules/NewStandardFindings/Changelog.txt
@@ -9,6 +9,10 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 ### Added
 - Neuer Button zum Auswählen einer Findings-JSON; die Auswahl wird eingelesen, gespeichert und der Dateipfad im Local Storage hinterlegt.
 - Kontextbereich zeigt nun den aktuell verwendeten Findings-Dateipfad an.
+- Schnellaktionen im Kopfbereich ermöglichen den direkten Zugriff auf die zuletzt genutzte Findings- oder Aspen-Datei ohne Umwege über das Kontextmenü.
+
+### Changed
+- Ausgewählte Findings-Pfade werden beim Laden synchronisiert und über Storage-Events zwischen Browser-Tabs aktuell gehalten.
 
 ## [1.2.2] – 2025-09-28
 ### Fixed

--- a/modules/ShopguideFindingsEditor/Changelog.txt
+++ b/modules/ShopguideFindingsEditor/Changelog.txt
@@ -9,9 +9,11 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 ### Added
 - Partnummern-Feld oberhalb des Labels mit dynamischen Eingabezeilen und "Plus"-Schaltfläche für mehrere Nummern.
 - Anzeige der Partnummern als Untertitel in der Findings-Liste inklusive Such- und Kopierunterstützung.
+- Globale Suche akzeptiert nun Wildcards (`*`) und hebt die Treffer in Listen- und Editoransichten hervor.
 
 ### Changed
 - Export in alle unterstützten Formate übernimmt bereinigte Partnummernlisten.
+- Die Suchlogik durchsucht jetzt sämtliche Eingabefelder samt Partnummernlisten aus dem Bestellraster, sodass relevante Informationen zusammenhängend gefunden werden.
 
 ### Fixed
 - Bestehende `Part`-Felder werden nun als Partnummern übernommen und beim Speichern aktualisiert.


### PR DESCRIPTION
## Summary
- detail the Shopguide Findings Editor 1.2.0 changelog with wildcard search support and expanded search coverage
- extend the New Standard Findings 1.2.3 changelog (TXT and Markdown) with quick actions and storage synchronization notes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d563f65d00832db0efac0f5ad3e352