### PR TITLE
Update NewStandardFindings changelog for 1.2.4

### DIFF
--- a/modules/NewStandardFindings/CHANGELOG.md
+++ b/modules/NewStandardFindings/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Alle relevanten Änderungen ab Version 1.2.0 werden hier in Kurzform dokumentiert.
 
+## 1.2.4 – 2025-09-26
+### Changed
+- Die Kopierfunktion der Bestellliste liefert nur noch die identifizierten Teilenummern zurück, damit keine Mengenangaben mehr in andere Tools übertragen werden.
+
 ## 1.2.3 – 2025-09-29
 ### Added
 - Schaltfläche zum Laden einer benutzerdefinierten Findings-Datei inklusive Speicherung des Dateipfads im Local Storage.

--- a/modules/NewStandardFindings/Changelog.txt
+++ b/modules/NewStandardFindings/Changelog.txt
@@ -5,6 +5,10 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 
 ---
 
+## [1.2.4] – 2025-09-26
+### Changed
+- Kopierfunktion der Bestellliste gibt nur noch die extrahierten Teilenummern zurück, sodass Mengenangaben nicht mehr in andere Anwendungen übernommen werden.
+
 ## [1.2.3] – 2025-09-29
 ### Added
 - Neuer Button zum Auswählen einer Findings-JSON; die Auswahl wird eingelesen, gespeichert und der Dateipfad im Local Storage hinterlegt.

--- a/modules/NewStandardFindings/NewStandardFindings.json
+++ b/modules/NewStandardFindings/NewStandardFindings.json
@@ -7,5 +7,5 @@
   "minW": 2,
   "minH": 12,
   "moduleId": "NewStandardFindings",
-  "version": "1.2.3"
+  "version": "1.2.4"
 }


### PR DESCRIPTION
## Summary
- document the latest Bestellliste copy behavior in both changelog variants for NewStandardFindings
- bump the module manifest to version 1.2.4

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d64f33a0a8832d8e5dcc5adf49cf7b