### PR TITLE
chore: bump module versions for findings tools

### DIFF
--- a/modules/AspenUnitList/AspenUnitList.json
+++ b/modules/AspenUnitList/AspenUnitList.json
@@ -10,5 +10,5 @@
     "title": "Aspen Board"
   },
   "moduleId": "AspenUnitList",
-  "version": "1.1.8"
+  "version": "1.1.9"
 }

--- a/modules/AspenUnitList/Changelog.txt
+++ b/modules/AspenUnitList/Changelog.txt
@@ -5,6 +5,10 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 
 ---
 
+## [1.1.9] – 2025-09-26
+### Changed
+- Modulmanifest aktualisiert und die Version auf 1.1.9 erhöht.
+
 ## [1.1.8] – 2025-09-24
 ### Changed
 - Kontextmenü, Modaldialog und Konfigurationspanel erhalten höhere Z-Indizes, damit sie zuverlässig über anderen Overlays des Dashboards liegen.

--- a/modules/NewStandardFindings/Changelog.txt
+++ b/modules/NewStandardFindings/Changelog.txt
@@ -5,6 +5,10 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 
 ---
 
+## [1.2.5] – 2025-09-26
+### Changed
+- Modulmanifest aktualisiert und die Version auf 1.2.5 erhöht.
+
 ## [1.2.4] – 2025-09-26
 ### Changed
 - Kopierfunktion der Bestellliste gibt nur noch die extrahierten Teilenummern zurück, sodass Mengenangaben nicht mehr in andere Anwendungen übernommen werden.

--- a/modules/NewStandardFindings/NewStandardFindings.json
+++ b/modules/NewStandardFindings/NewStandardFindings.json
@@ -7,5 +7,5 @@
   "minW": 2,
   "minH": 12,
   "moduleId": "NewStandardFindings",
-  "version": "1.2.4"
+  "version": "1.2.5"
 }

--- a/modules/ShopguideFindingsEditor/Changelog.txt
+++ b/modules/ShopguideFindingsEditor/Changelog.txt
@@ -5,6 +5,10 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 
 ---
 
+## [1.2.1] – 2025-09-26
+### Changed
+- Modulmanifest aktualisiert und die Version auf 1.2.1 erhöht.
+
 ## [1.2.0] – 2025-09-29
 ### Added
 - Partnummern-Feld oberhalb des Labels mit dynamischen Eingabezeilen und "Plus"-Schaltfläche für mehrere Nummern.

--- a/modules/ShopguideFindingsEditor/ShopguideFindingsEditor.json
+++ b/modules/ShopguideFindingsEditor/ShopguideFindingsEditor.json
@@ -7,5 +7,5 @@
   "minW": 4,
   "minH": 10,
   "moduleId": "ShopguideFindingsEditor",
-  "version": "1.2.0"
+  "version": "1.2.1"
 }


### PR DESCRIPTION
## Summary
- bump the manifest versions for the New Standard Findings, Aspen Board, and Shopguide Findings Editor modules
- document the 2025-09-26 version updates in each module changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d662e242a4832d94ebb1c4378c0ed0