### PR TITLE
Switch LinkButtons Plus to Aspen data source

### DIFF
--- a/modules/LinkButtonsPlus/Changelog.txt
+++ b/modules/LinkButtonsPlus/Changelog.txt
@@ -5,6 +5,11 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 
 ---
 
+## [1.3.8] – 2025-09-26
+### Changed
+- Meldungs- und Auftragsdaten werden jetzt aus der gewählten Aspen-Datei gelesen (statt aus dem Dictionary).
+- Kontextmenü und Dateiauswahl wurden auf die Aspen-Anbindung angepasst.
+
 ## [1.3.7] – 2025-09-23
 ### Changed
 - Changelog-Datei in LinkButtonPlusChangelog.txt umbenannt

--- a/modules/LinkButtonsPlus/LinkButtonsPlus.json
+++ b/modules/LinkButtonsPlus/LinkButtonsPlus.json
@@ -19,5 +19,5 @@
     ]
   },
   "moduleId": "LinkButtonsPlus",
-  "version": "1.3.7"
+  "version": "1.3.8"
 }


### PR DESCRIPTION
## Summary
- load Meldung/Auftragsnummer (and related fields) from the selected Aspen Excel file instead of the dictionary workbook
- update the context menu copy, stored handle key, and cached file name handling to reflect the Aspen data source
- bump the module manifest and changelog to document the new Aspen integration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6811f1318832da9ec7dfa4da7d5bf