### PR TITLE
Refactor Gerätedaten to rely on Aspen file only

### DIFF
--- a/modules/Gerätedaten/Changelog.txt
+++ b/modules/Gerätedaten/Changelog.txt
@@ -5,6 +5,11 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 
 ---
 
+## [1.4.0] – 2025-09-30
+### Changed
+- Gerätedaten lesen jetzt ausschließlich aus der Aspen-Datei; Dictionary-Unterstützung entfernt und Eingabefelder auf Lesezugriff umgestellt.
+- Aspen-Datei wird beim Laden vollständig eingelesen, sodass Felder automatisch auf verfügbare Spalten abgebildet werden.
+
 ## [1.3.4] – 2025-09-23
 ### Changed
 - Modulbreite auf Minimalwerte reduziert

--- a/modules/Gerätedaten/Changelog.txt
+++ b/modules/Gerätedaten/Changelog.txt
@@ -5,6 +5,11 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 
 ---
 
+## [1.4.1] – 2025-10-01
+### Fixed
+- Fehlerzustände werden nun direkt im Kopfbereich angezeigt, inklusive Debug-Hinweisen bei Problemen mit Dateiauswahl oder Berechtigungen.
+- Inline-Auswahl der Aspen-Datei öffnet jetzt zuverlässig die Optionen, wenn der File-Picker nicht unterstützt wird.
+
 ## [1.4.0] – 2025-09-30
 ### Changed
 - Gerätedaten lesen jetzt ausschließlich aus der Aspen-Datei; Dictionary-Unterstützung entfernt und Eingabefelder auf Lesezugriff umgestellt.

--- a/modules/Gerätedaten/Gerätedaten.json
+++ b/modules/Gerätedaten/Gerätedaten.json
@@ -37,5 +37,5 @@
     ]
   },
   "moduleId": "Gerätedaten",
-  "version": "1.4.0"
+  "version": "1.4.1"
 }

--- a/modules/Gerätedaten/Gerätedaten.json
+++ b/modules/Gerätedaten/Gerätedaten.json
@@ -37,5 +37,5 @@
     ]
   },
   "moduleId": "Gerätedaten",
-  "version": "1.3.4"
+  "version": "1.4.0"
 }

--- a/modules/Gerätedaten/V1d.js
+++ b/modules/Gerätedaten/V1d.js
@@ -498,7 +498,22 @@
     let lastDocString=getDocString();
     const watcher=setInterval(()=>{const now=getDocString();if(now!==lastDocString){lastDocString=now;refreshFromAspen();}},WATCH_INTERVAL);
 
-    const openAspenPicker=async()=>{try{const [handle]=await showOpenFilePicker({types:[{description:'Excel',accept:{'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':['.xlsx']}}],excludeAcceptAllOption:false,multiple:false});if(handle)await bindAspenHandle(handle);}catch(e){if(e?.name!=='AbortError')setNote('Auswahl fehlgeschlagen.');}};
+    const openAspenPicker=async()=>{
+      const picker=typeof window.showOpenFilePicker==='function'
+        ? window.showOpenFilePicker.bind(window)
+        : null;
+      if(!picker){
+        toggleModal(true);
+        setNote('Dateiauswahl wird nicht unterstützt. Bitte über die Optionen öffnen.');
+        return;
+      }
+      try{
+        const [handle]=await picker({types:[{description:'Excel',accept:{'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':['.xlsx']}}],excludeAcceptAllOption:false,multiple:false});
+        if(handle)await bindAspenHandle(handle);
+      }catch(e){
+        if(e?.name!=='AbortError')setNote('Auswahl fehlgeschlagen.');
+      }
+    };
     if(els.mAspenPick)els.mAspenPick.addEventListener('click',openAspenPicker);
     if(els.aspenInlineBtn)els.aspenInlineBtn.addEventListener('click',openAspenPicker);
     updateAspenFieldList();


### PR DESCRIPTION
## Summary
- remove the dictionary picker and all dictionary persistence code from Gerätedaten
- load records exclusively from the selected Aspen workbook and resolve configured fields against Aspen headers
- refresh device fields from Aspen data in read-only inputs and bump the module version/changelog

## Testing
- Not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68dbd7e4119c832d84e5a058915ccb65