### PR TITLE
Add Shopguide parameter inserts and preview tabs to routine editor

### DIFF
--- a/modules/NewStandardFindings/NewStandardFindings.js
+++ b/modules/NewStandardFindings/NewStandardFindings.js
@@ -4358,8 +4358,6 @@
     }
 
     renderRoutineEditorOverlayContent(){
-    renderRoutineEditorOverlayContent(){
-    renderRoutineEditorOverlayContent(){
       if(!this.routineEditorList) return;
       this.prepareRoutineEditorParameterOptions();
       this.updateRoutineEditorParameterFilterState();
@@ -4441,7 +4439,6 @@
       });
     }
 
-    addRoutineEditorParameterBlockAt(index,option){
     addRoutineEditorParameterBlockAt(index,option){
       if(!option) return;
       const valueText=typeof option.value==='string'?option.value:'';
@@ -4914,9 +4911,7 @@
       if(config&&config.primaryTextarea===key){
         const textarea=this.textareas&&this.textareas[key];
         const value=textarea?textarea.value:'';
-        const segments=value.split(/
-?
-/);
+        const segments=value.split(/\r?\n/);
         return segments;
       }
       const tabState=this.getRoutineEditorTabState();
@@ -5558,9 +5553,7 @@
       if(config&&config.primaryTextarea===key){
         const textarea=this.textareas&&this.textareas[key];
         const value=textarea?textarea.value:'';
-        const segments=value.split(/
-?
-/);
+        const segments=value.split(/\r?\n/);
         return segments.map(segment=>segment?segment:ROUTINE_EDITOR_LINE_BREAK_TOKEN);
       }
       const tabState=this.getRoutineEditorTabState();

--- a/modules/NewStandardFindings/NewStandardFindings.js
+++ b/modules/NewStandardFindings/NewStandardFindings.js
@@ -41,6 +41,15 @@
     {key:'times',label:'Arbeitszeiten',getter:entry=>entry.times||''},
     {key:'mods',label:'Modifikationen',getter:entry=>entry.mods||''}
   ];
+
+  const OUTPUT_DEFS=[
+    {key:'findings',label:'Findings'},
+    {key:'actions',label:'Actions'},
+    {key:'routine',label:'Routine'},
+    {key:'nonroutine',label:'Nonroutine'},
+    {key:'parts',label:'Bestellliste'}
+  ];
+
   const ROUTINE_EDITOR_PREVIEW_TAB_KEYS=OUTPUT_DEFS.filter(def=>def.key!=='parts').map(def=>def.key);
 
   function sanitizeRoutineEditorLabel(value){
@@ -53,14 +62,6 @@
     textarea.style.height='auto';
     textarea.style.height=`${Math.max(textarea.scrollHeight,textarea.dataset.minHeight?Number(textarea.dataset.minHeight):0)}px`;
   }
-
-  const OUTPUT_DEFS=[
-    {key:'findings',label:'Findings'},
-    {key:'actions',label:'Actions'},
-    {key:'routine',label:'Routine'},
-    {key:'nonroutine',label:'Nonroutine'},
-    {key:'parts',label:'Bestellliste'}
-  ];
 
   const OUTPUT_KEYS=OUTPUT_DEFS.map(def=>def.key);
   const CUSTOM_SLOT_COUNT=OUTPUT_DEFS.length+1;

--- a/modules/NewStandardFindings/NewStandardFindings.js
+++ b/modules/NewStandardFindings/NewStandardFindings.js
@@ -91,6 +91,15 @@
     return value.trim().slice(0,120);
   }
 
+  function sanitizePresetName(name){
+    if(typeof name!=='string') return '';
+    return name.trim().slice(0,80);
+  }
+
+  function createRoutinePresetId(){
+    return `preset-${Date.now().toString(36)}-${Math.random().toString(36).slice(2,8)}`;
+  }
+
   function autoSizeTextarea(textarea){
     if(!textarea) return;
     textarea.style.height='auto';
@@ -166,6 +175,26 @@
 
   function getRoutineEditorTabKey(tabKey){
     return ROUTINE_EDITOR_PREVIEW_TAB_KEYS.includes(tabKey)?tabKey:'routine';
+  }
+
+  function loadRoutineEditorActiveTab(){
+    try{
+      const raw=localStorage.getItem(ROUTINE_EDITOR_ACTIVE_TAB_KEY);
+      if(!raw) return 'routine';
+      return getRoutineEditorTabKey(String(raw));
+    }catch(err){
+      console.warn('NSF: Aktiver Routine-Tab konnte nicht geladen werden',err);
+      return 'routine';
+    }
+  }
+
+  function storeRoutineEditorActiveTab(tabKey){
+    try{
+      const key=getRoutineEditorTabKey(tabKey);
+      localStorage.setItem(ROUTINE_EDITOR_ACTIVE_TAB_KEY,key);
+    }catch(err){
+      console.warn('NSF: Aktiver Routine-Tab konnte nicht gespeichert werden',err);
+    }
   }
 
   function getRoutineEditorTabConfig(tabKey){
@@ -483,6 +512,44 @@
       }
     }catch(err){
       console.warn('NSF: Aktives Routine-Profil konnte nicht gespeichert werden',err);
+    }
+  }
+
+  function loadRoutineEditorParameterFavorites(){
+    try{
+      const raw=localStorage.getItem(ROUTINE_EDITOR_PARAMETER_FAVORITES_KEY);
+      if(!raw) return [];
+      const parsed=JSON.parse(raw);
+      if(!Array.isArray(parsed)) return [];
+      const seen=new Set();
+      const favorites=[];
+      parsed.forEach(entry=>{
+        if(typeof entry!=='string') return;
+        const key=entry.trim();
+        if(!key||seen.has(key)) return;
+        seen.add(key);
+        favorites.push(key);
+      });
+      return favorites;
+    }catch(err){
+      console.warn('NSF: Routine-Parameter-Favoriten konnten nicht geladen werden',err);
+      return [];
+    }
+  }
+
+  function storeRoutineEditorParameterFavorites(favorites){
+    try{
+      const seen=new Set();
+      const payload=Array.isArray(favorites)?favorites.map(entry=>{
+        if(typeof entry!=='string') return '';
+        const key=entry.trim();
+        if(!key||seen.has(key)) return '';
+        seen.add(key);
+        return key;
+      }).filter(Boolean):[];
+      localStorage.setItem(ROUTINE_EDITOR_PARAMETER_FAVORITES_KEY,JSON.stringify(payload));
+    }catch(err){
+      console.warn('NSF: Routine-Parameter-Favoriten konnten nicht gespeichert werden',err);
     }
   }
 


### PR DESCRIPTION
## Summary
- allow custom text fields to persist as empty line breaks in routine preview and output
- surface Shopguide parameter options in the insert control with favorites support and persistence
- add preview tab switching across routine, findings, actions, and nonroutine outputs in the overlay

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbd53d05a8832da96bc5d5289951a2