### PR TITLE
Improve Aspen header detection

### DIFF
--- a/modules/AspenComments/AspenComments.js
+++ b/modules/AspenComments/AspenComments.js
@@ -451,6 +451,13 @@
     return `${normalizeKey(meldung)}||${normalizeKey(part)}||${normalizeKey(serial)}`;
   }
 
+  function normalizePartValue(value){
+    const text=trim(value);
+    if(!text) return '';
+    const [first]=text.split(':');
+    return trim(first);
+  }
+
   function createAspenDebug(){
     return {
       sheetNames:[],
@@ -914,13 +921,6 @@
       }
       const ok=await loadAspenHandle(state.aspenHandle,{updateName:false});
       if(ok) flashNote('Aspen neu geladen','success');
-    }
-
-    function normalizePartValue(value){
-      const text=trim(value);
-      if(!text) return '';
-      const [first]=text.split(':');
-      return trim(first);
     }
 
     function updateAspenStatus(entry,{manualSelection=false}={}){

--- a/modules/AspenComments/AspenComments.js
+++ b/modules/AspenComments/AspenComments.js
@@ -46,12 +46,56 @@
   const COMMENTS_SHEET='Comments';
   const WATCH_INTERVAL=500;
 
-  const MELD_HEADER_PRIORITY=['MELDUNGS_NO','MELDUNGSNR','MELDUNG_NR'];
-  const PART_HEADER_PRIORITY=['PART_NO','PARTNR','PART_NUMBER','PARTNUMBER'];
-  const SERIAL_HEADER_PRIORITY=['SERIAL_NO','SERIALNR','SERIAL_NUMBER','SERIALNUMBER'];
-  const MELD_PATTERNS=[/meldung/i,/meldung\s*nr/i,/meldungnummer/i,/message/i];
-  const PART_PATTERNS=[/part/i,/p\/?n/i,/artikel/i,/material/i];
-  const SERIAL_PATTERNS=[/serial/i,/sn/i,/serien/i];
+  const MELD_HEADER_PRIORITY=[
+    'MELDUNGS_NO',
+    'MELDUNGSNR',
+    'MELDUNG_NR',
+    'MELDUNG',
+    'MELDUNGNR',
+    'MELDUNGNO',
+    'MELD_NR',
+    'MELD_NO',
+    'MELDNR',
+    'MELDNO',
+    'MELDE_NR'
+  ];
+  const PART_HEADER_PRIORITY=[
+    'PART_NO',
+    'PARTNR',
+    'PART_NUMBER',
+    'PARTNUMBER',
+    'MATNR',
+    'MATERIAL_NR',
+    'MATERIALNR',
+    'MATERIALNO',
+    'ARTNR',
+    'ARTIKELNR',
+    'ARTIKEL_NO'
+  ];
+  const SERIAL_HEADER_PRIORITY=[
+    'SERIAL_NO',
+    'SERIALNR',
+    'SERIAL_NUMBER',
+    'SERIALNUMBER',
+    'SNR',
+    'S_NR',
+    'SN',
+    'GERAETENR',
+    'GERÄTENR',
+    'GERAETE_NR',
+    'GERÄTE_NR'
+  ];
+  const MELD_PATTERNS=[
+    /\bmeldung\b/i,
+    /\bmeldung\s*nr\b/i,
+    /\bmeldung\s*no\b/i,
+    /\bmeld\s*nr\b/i,
+    /\bmeld\s*no\b/i,
+    /meldungnummer/i,
+    /\bmessage\b/i
+  ];
+  const PART_PATTERNS=[/part/i,/p\/?n/i,/artikel/i,/material/i,/matnr/i,/ger[aä]t/i];
+  const SERIAL_PATTERNS=[/serial/i,/sn/i,/serien/i,/s\.?nr/i,/geraetenr/i,/ger[aä]te?nr/i];
   const COMMENT_PATTERNS=[/comment/i,/bemerk/i,/notiz/i,/note/i,/hinweis/i];
   const HEADER_SCAN_LIMIT=25;
   const HEADER_MAX_SCORE=14;


### PR DESCRIPTION
## Summary
- broaden the Aspen Excel header detection to recognise additional Meldung, Part and Serial column labels
- add extra pattern fallbacks for German umlauts and alternative abbreviations to avoid empty Aspen imports

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd082c7cc0832d8831a34d3aca257d