### PR TITLE
Fix insertion position for routine editor text fields

### DIFF
--- a/modules/NewStandardFindings/NewStandardFindings.js
+++ b/modules/NewStandardFindings/NewStandardFindings.js
@@ -4547,9 +4547,10 @@
         }
       }
       tabState.customBlocks.push(entry);
-      const order=this.getRoutineEditorOrder();
+      const customKey=`${ROUTINE_EDITOR_CUSTOM_PREFIX}${id}`;
+      const order=this.getRoutineEditorOrder().filter(entry=>entry!==customKey);
       const clampedIndex=this.normalizeRoutineEditorInsertIndex(index,order.length);
-      order.splice(clampedIndex,0,`${ROUTINE_EDITOR_CUSTOM_PREFIX}${id}`);
+      order.splice(clampedIndex,0,customKey);
       tabState.order=order;
       this.renderRoutineEditorOverlayContent();
       this.syncRoutineEditorStateFromDom();

--- a/modules/NewStandardFindings/NewStandardFindings.js
+++ b/modules/NewStandardFindings/NewStandardFindings.js
@@ -4514,6 +4514,12 @@
       const allowAspen=config&&config.allowAspen!==false;
       const id=createCustomSectionId();
       if(!Array.isArray(tabState.customBlocks)) tabState.customBlocks=[];
+      const currentOrder=this.getRoutineEditorOrder();
+      const clampedIndex=this.normalizeRoutineEditorInsertIndex(index,currentOrder.length);
+      const customInsertIndex=currentOrder
+        .slice(0,clampedIndex)
+        .filter(entry=>typeof entry==='string'&&entry.startsWith(ROUTINE_EDITOR_CUSTOM_PREFIX))
+        .length;
       const requestedType=typeof type==='string'?type:'';
       const blockType=requestedType==='linebreak'?'linebreak':requestedType==='aspen'&&allowAspen?'aspen':'text';
       const entry={
@@ -4546,10 +4552,9 @@
           entry.lines=presetLines;
         }
       }
-      tabState.customBlocks.push(entry);
+      tabState.customBlocks.splice(customInsertIndex,0,entry);
       const customKey=`${ROUTINE_EDITOR_CUSTOM_PREFIX}${id}`;
-      const order=this.getRoutineEditorOrder().filter(entry=>entry!==customKey);
-      const clampedIndex=this.normalizeRoutineEditorInsertIndex(index,order.length);
+      const order=currentOrder.filter(entry=>entry!==customKey);
       order.splice(clampedIndex,0,customKey);
       tabState.order=order;
       this.renderRoutineEditorOverlayContent();

--- a/modules/NewStandardFindings/NewStandardFindings.js
+++ b/modules/NewStandardFindings/NewStandardFindings.js
@@ -4495,6 +4495,19 @@
       this.refreshRoutineEditorPreview();
     }
 
+    normalizeRoutineEditorInsertIndex(index,length){
+      const numericIndex=typeof index==='number'&&Number.isFinite(index)
+        ?index
+        :typeof index==='string'&&index.trim()!==''
+          ?Number.parseInt(index,10)
+          :NaN;
+      if(Number.isFinite(numericIndex)){
+        const max=Math.max(0,Number.isFinite(length)?length:0);
+        return Math.max(0,Math.min(numericIndex,max));
+      }
+      return Math.max(0,Number.isFinite(length)?length:0);
+    }
+
     addRoutineEditorCustomBlockAt(index,type='text',options={}){
       const tabState=this.getRoutineEditorTabState();
       const config=this.getRoutineEditorTabConfig();
@@ -4535,7 +4548,7 @@
       }
       tabState.customBlocks.push(entry);
       const order=this.getRoutineEditorOrder();
-      const clampedIndex=Math.max(0,Math.min(Number.isFinite(index)?index:order.length,order.length));
+      const clampedIndex=this.normalizeRoutineEditorInsertIndex(index,order.length);
       order.splice(clampedIndex,0,`${ROUTINE_EDITOR_CUSTOM_PREFIX}${id}`);
       tabState.order=order;
       this.renderRoutineEditorOverlayContent();
@@ -4697,7 +4710,7 @@
       if(!def||def.removable===false) return;
       const tabState=this.getRoutineEditorTabState();
       const order=this.getRoutineEditorOrder().filter(entry=>entry!==key);
-      const clampedIndex=Math.max(0,Math.min(Number.isFinite(index)?index:order.length,order.length));
+      const clampedIndex=this.normalizeRoutineEditorInsertIndex(index,order.length);
       order.splice(clampedIndex,0,key);
       tabState.order=order;
       if(Array.isArray(tabState.hiddenBaseBlocks)){


### PR DESCRIPTION
## Summary
- normalize routine editor insert indices so custom and base blocks are placed where requested
- reuse the new index helper for both custom and base block insertion paths

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd1ac7a780832d846bc76a7f06d1c1