### PR TITLE
Enable auto-saving for Aspen board settings

### DIFF
--- a/modules/AspenUnitList/AspenBoard.js
+++ b/modules/AspenUnitList/AspenBoard.js
@@ -551,7 +551,7 @@ der-radius:.4rem;background:transparent;color:inherit;}
   function createElements(initialTitle){
     const root=document.createElement('div');
     root.className='db-root';
-    root.innerHTML=`<div class="db-titlebar" hidden><div class="db-title-group"><span class="db-title-text"></span><span class="db-title-meta" hidden></span><span class="db-title-status" hidden role="status" aria-live="polite"><span class="db-status-icon" aria-hidden="true"></span><span class="db-status-text"></span></span><span class="db-title-hint" hidden></span></div><button type="button" class="db-refresh" title="Aspen-Datei aktualisieren">↻</button></div><div class="db-surface"><div class="db-toolbar"><input type="search" class="db-search" placeholder="Geräte suchen…"><button type="button" class="db-toggle-active" aria-pressed="false" title="Aktive Geräteliste umschalten">Aktive Geräte</button></div><div class="db-lists"><div class="db-list-wrap db-main-wrap"><div class="db-list db-main-list" data-board-type="aspen-unit"></div></div><div class="db-list-wrap db-active-wrap" hidden><div class="db-list-title">Aktive Geräte</div><div class="db-list db-active-list" data-board-type="aspen-active"></div></div></div></div><div class="db-modal"><div class="db-panel"><div class="row"><label>Titel (optional)<input type="text" class="db-title-input"></label></div><div class="row rules"><div class="db-row-header"><div class="db-rule-label">Titel-Logik (Wenn/Dann)</div><div class="db-row-actions"><button type="button" class="db-icon-btn db-rule-import" title="Regeln importieren" aria-label="Regeln importieren">📥</button><button type="button" class="db-icon-btn db-rule-export" title="Regeln exportieren" aria-label="Regeln exportieren">📤</button></div></div><div class="db-rule-list"></div><button type="button" class="db-add-rule">Regel hinzufügen</button></div><div class="row subs"><div class="db-row-header"><label>Untertitel-Felder</label><div class="db-row-actions"><button type="button" class="db-icon-btn db-sub-import" title="Untertitel importieren" aria-label="Untertitel importieren">📥</button><button type="button" class="db-icon-btn db-sub-export" title="Untertitel exportieren" aria-label="Untertitel exportieren">📤</button></div></div><div class="db-sub-list"></div><button type="button" class="db-add-sub">+</button></div><div class="row"><label>Dropdownkriterium<div class="db-part-select"><input type="text" class="db-part-select-input" placeholder="Spalte wählen"><div class="db-part-options"></div></div><select class="db-sel-part" hidden></select></label></div><div class="row"><label>Hintergrund<input type="color" class="db-color db-c-bg" value="#f5f7fb"></label></div><div class="row"><label>Item Hintergrund<input type="color" class="db-color db-c-item" value="#ffffff"></label></div><div class="row"><label>Titelfarbe<input type="color" class="db-color db-c-title" value="#2563eb"></label></div><div class="row"><label>Untertitel-Farbe<input type="color" class="db-color db-c-sub" value="#4b5563"></label></div><div class="row"><label>Aktiv-Highlight<input type="color" class="db-color db-c-active" value="#10b981"></label></div><div class="actions"><button class="db-save">Speichern</button><button class="db-close">Schließen</button></div></div></div>`;
+    root.innerHTML=`<div class="db-titlebar" hidden><div class="db-title-group"><span class="db-title-text"></span><span class="db-title-meta" hidden></span><span class="db-title-status" hidden role="status" aria-live="polite"><span class="db-status-icon" aria-hidden="true"></span><span class="db-status-text"></span></span><span class="db-title-hint" hidden></span></div><button type="button" class="db-refresh" title="Aspen-Datei aktualisieren">↻</button></div><div class="db-surface"><div class="db-toolbar"><input type="search" class="db-search" placeholder="Geräte suchen…"><button type="button" class="db-toggle-active" aria-pressed="false" title="Aktive Geräteliste umschalten">Aktive Geräte</button></div><div class="db-lists"><div class="db-list-wrap db-main-wrap"><div class="db-list db-main-list" data-board-type="aspen-unit"></div></div><div class="db-list-wrap db-active-wrap" hidden><div class="db-list-title">Aktive Geräte</div><div class="db-list db-active-list" data-board-type="aspen-active"></div></div></div></div><div class="db-modal"><div class="db-panel"><div class="row"><label>Titel (optional)<input type="text" class="db-title-input"></label></div><div class="row rules"><div class="db-row-header"><div class="db-rule-label">Titel-Logik (Wenn/Dann)</div><div class="db-row-actions"><button type="button" class="db-icon-btn db-rule-import" title="Regeln importieren" aria-label="Regeln importieren">📥</button><button type="button" class="db-icon-btn db-rule-export" title="Regeln exportieren" aria-label="Regeln exportieren">📤</button></div></div><div class="db-rule-list"></div><button type="button" class="db-add-rule">Regel hinzufügen</button></div><div class="row subs"><div class="db-row-header"><label>Untertitel-Felder</label><div class="db-row-actions"><button type="button" class="db-icon-btn db-sub-import" title="Untertitel importieren" aria-label="Untertitel importieren">📥</button><button type="button" class="db-icon-btn db-sub-export" title="Untertitel exportieren" aria-label="Untertitel exportieren">📤</button></div></div><div class="db-sub-list"></div><button type="button" class="db-add-sub">+</button></div><div class="row"><label>Dropdownkriterium<div class="db-part-select"><input type="text" class="db-part-select-input" placeholder="Spalte wählen"><div class="db-part-options"></div></div><select class="db-sel-part" hidden></select></label></div><div class="row"><label>Hintergrund<input type="color" class="db-color db-c-bg" value="#f5f7fb"></label></div><div class="row"><label>Item Hintergrund<input type="color" class="db-color db-c-item" value="#ffffff"></label></div><div class="row"><label>Titelfarbe<input type="color" class="db-color db-c-title" value="#2563eb"></label></div><div class="row"><label>Untertitel-Farbe<input type="color" class="db-color db-c-sub" value="#4b5563"></label></div><div class="row"><label>Aktiv-Highlight<input type="color" class="db-color db-c-active" value="#10b981"></label></div></div></div>`;
 
     const titleBar=root.querySelector('.db-titlebar');
     if(titleBar){
@@ -593,8 +593,6 @@ der-radius:.4rem;background:transparent;color:inherit;}
       partSelectWrap:root.querySelector('.db-part-select'),
       partSelectInput:root.querySelector('.db-part-select-input'),
       partSelectOptions:root.querySelector('.db-part-options'),
-      saveBtn:root.querySelector('.db-save'),
-      closeBtn:root.querySelector('.db-close'),
       cBg:root.querySelector('.db-c-bg'),
       cItem:root.querySelector('.db-c-item'),
       cTitle:root.querySelector('.db-c-title'),
@@ -1094,6 +1092,76 @@ der-radius:.4rem;background:transparent;color:inherit;}
     let partSelectOpen=false;
     let highlightedPartIndex=-1;
     let partSelectOutsideHandler=null;
+    let optionPersistTimer=null;
+
+    function applyOptionChanges(){
+      if(elements.subList){
+        elements.subList.querySelectorAll('.db-sub-input').forEach(input=>{
+          input.dispatchEvent(new Event('change'));
+        });
+      }
+      if(elements.ruleList){
+        elements.ruleList.querySelectorAll('.db-rule-field').forEach(input=>{
+          input.dispatchEvent(new Event('change'));
+        });
+      }
+      if(elements.titleInput){
+        state.config.title=elements.titleInput.value.trim();
+      }
+      const newPart=elements.selPart?.value||'';
+      const partChanged=newPart && state.config.partField!==newPart;
+      if(newPart){
+        state.config.partField=newPart;
+      }
+      const collected=(tempSubFields||[]).map(value=>String(value||'').trim()).filter(Boolean);
+      const availableSubFields=getAvailableFieldList(state);
+      state.config.subFields=collected.length?collected:[availableSubFields[0]||DEFAULT_SUB_FIELD];
+      const preparedRules=(tempTitleRules||[]).map(rule=>normalizeTitleRule(rule)).map(rule=>({
+        field:(rule.field||'').trim(),
+        operator:normalizeOperator(rule.operator),
+        value:typeof rule.value==='string'?rule.value.trim():(rule.value==null?'':String(rule.value).trim()),
+        text:(rule.text||'').trim()
+      })).filter(rule=>rule.field&&rule.text);
+      state.config.titleRules=preparedRules;
+      state.config.colors={
+        bg:elements.cBg?.value||state.config.colors.bg,
+        item:elements.cItem?.value||state.config.colors.item,
+        title:elements.cTitle?.value||state.config.colors.title,
+        sub:elements.cSub?.value||state.config.colors.sub,
+        active:elements.cActive?.value||state.config.colors.active
+      };
+      refreshTitleBar();
+      applyColors(elements.root,state.config.colors);
+      if(partChanged){
+        state.items.forEach(item=>{
+          const raw=String(item.data?.[newPart]||'').trim();
+          const part=(raw.split(':')[0]||'').trim();
+          item.part=part;
+          item.data={...item.data,[newPart]:part};
+        });
+        state.excluded.clear();
+      }
+      persistState(state);
+      render();
+    }
+
+    function scheduleOptionPersist(immediate=false){
+      if(immediate){
+        if(optionPersistTimer){
+          clearTimeout(optionPersistTimer);
+          optionPersistTimer=null;
+        }
+        applyOptionChanges();
+        return;
+      }
+      if(optionPersistTimer){
+        clearTimeout(optionPersistTimer);
+      }
+      optionPersistTimer=setTimeout(()=>{
+        optionPersistTimer=null;
+        applyOptionChanges();
+      },200);
+    }
 
     function showAlert(message){
       if(typeof window!=='undefined' && typeof window.alert==='function'){
@@ -1577,6 +1645,7 @@ der-radius:.4rem;background:transparent;color:inherit;}
             tempSubFields[index]='';
             input.value='';
             renderOptions();
+            scheduleOptionPersist();
             return;
           }
           const exact=choices.find(opt=>opt.toLowerCase()===raw.toLowerCase());
@@ -1584,6 +1653,7 @@ der-radius:.4rem;background:transparent;color:inherit;}
             tempSubFields[index]=exact;
             input.value=exact;
             renderOptions();
+            scheduleOptionPersist();
             return;
           }
           const partial=choices.find(opt=>opt.toLowerCase().includes(raw.toLowerCase()));
@@ -1591,10 +1661,12 @@ der-radius:.4rem;background:transparent;color:inherit;}
             tempSubFields[index]=partial;
             input.value=partial;
             renderOptions();
+            scheduleOptionPersist();
             return;
           }
           input.value=tempSubFields[index]||'';
           renderOptions();
+          scheduleOptionPersist();
         };
         input.addEventListener('input',()=>{renderOptions(input.value);});
         input.addEventListener('focus',()=>{renderOptions();});
@@ -1638,6 +1710,7 @@ der-radius:.4rem;background:transparent;color:inherit;}
             tempSubFields[0]='';
           }
           renderSubFieldControls();
+          scheduleOptionPersist();
         });
         row.appendChild(removeBtn);
 
@@ -1687,6 +1760,7 @@ der-radius:.4rem;background:transparent;color:inherit;}
             tempTitleRules[index].field='';
             fieldInput.value='';
             renderFieldOptions();
+            scheduleOptionPersist();
             return;
           }
           const lower=raw.toLowerCase();
@@ -1695,6 +1769,7 @@ der-radius:.4rem;background:transparent;color:inherit;}
             tempTitleRules[index].field=exact;
             fieldInput.value=exact;
             renderFieldOptions();
+            scheduleOptionPersist();
             return;
           }
           const partial=fieldChoices.find(opt=>opt.toLowerCase().includes(lower));
@@ -1702,6 +1777,7 @@ der-radius:.4rem;background:transparent;color:inherit;}
             tempTitleRules[index].field=partial;
             fieldInput.value=partial;
             renderFieldOptions();
+            scheduleOptionPersist();
             return;
           }
           tempTitleRules[index].field=raw;
@@ -1710,11 +1786,13 @@ der-radius:.4rem;background:transparent;color:inherit;}
             fieldChoices.push(raw);
           }
           renderFieldOptions();
+          scheduleOptionPersist();
         };
         renderFieldOptions();
         fieldInput.addEventListener('input',()=>{
           renderFieldOptions(fieldInput.value);
           tempTitleRules[index].field=fieldInput.value;
+          scheduleOptionPersist();
         });
         fieldInput.addEventListener('focus',()=>{renderFieldOptions();});
         fieldInput.addEventListener('change',commitField);
@@ -1744,6 +1822,7 @@ der-radius:.4rem;background:transparent;color:inherit;}
         operatorSelect.value=currentOp;
         operatorSelect.addEventListener('change',()=>{
           tempTitleRules[index].operator=operatorSelect.value;
+          scheduleOptionPersist();
         });
         row.appendChild(operatorSelect);
 
@@ -1753,6 +1832,7 @@ der-radius:.4rem;background:transparent;color:inherit;}
         valueInput.value=normalized.value||'';
         valueInput.addEventListener('input',()=>{
           tempTitleRules[index].value=valueInput.value;
+          scheduleOptionPersist();
         });
         row.appendChild(valueInput);
 
@@ -1762,6 +1842,7 @@ der-radius:.4rem;background:transparent;color:inherit;}
         textInput.value=normalized.text||'';
         textInput.addEventListener('input',()=>{
           tempTitleRules[index].text=textInput.value;
+          scheduleOptionPersist();
         });
         row.appendChild(textInput);
 
@@ -1773,6 +1854,7 @@ der-radius:.4rem;background:transparent;color:inherit;}
         removeBtn.addEventListener('click',()=>{
           tempTitleRules.splice(index,1);
           renderRuleControls();
+          scheduleOptionPersist();
         });
         row.appendChild(removeBtn);
 
@@ -1798,11 +1880,34 @@ der-radius:.4rem;background:transparent;color:inherit;}
     }
     function closeOptions(){
       elements.modal.classList.remove('open');
+      scheduleOptionPersist(true);
       tempSubFields=[];
       tempTitleRules=[];
       closePartSelectDropdown();
       syncPartSelectInputValue();
     }
+
+    if(elements.modal){
+      elements.modal.addEventListener('mousedown',event=>{
+        if(event.target===elements.modal){
+          closeOptions();
+        }
+      });
+    }
+
+    const handleGlobalKeydown=event=>{
+      if(event.key==='Escape'){
+        if(event.defaultPrevented) return;
+        if(elements.modal?.classList.contains('open')){
+          if(partSelectOpen){
+            return;
+          }
+          event.preventDefault();
+          closeOptions();
+        }
+      }
+    };
+    document.addEventListener('keydown',handleGlobalKeydown);
 
     if(elements.addRuleBtn){
       elements.addRuleBtn.addEventListener('click',()=>{
@@ -1810,6 +1915,7 @@ der-radius:.4rem;background:transparent;color:inherit;}
         const defaultField=defaults[0]||'';
         tempTitleRules.push(normalizeTitleRule({field:defaultField,operator:'=',value:'',text:''}));
         renderRuleControls();
+        scheduleOptionPersist();
       });
     }
 
@@ -1831,6 +1937,7 @@ der-radius:.4rem;background:transparent;color:inherit;}
         tempTitleRules=imported.map(rule=>normalizeTitleRule(rule));
         renderRuleControls();
         showAlert('Regeln importiert.');
+        scheduleOptionPersist(true);
       });
     }
 
@@ -1844,6 +1951,7 @@ der-radius:.4rem;background:transparent;color:inherit;}
       const next=candidates.find(field=>!used.has(field))||candidates[0]||DEFAULT_SUB_FIELD;
       tempSubFields.push(next);
       renderSubFieldControls();
+      scheduleOptionPersist();
     });
 
     if(elements.subExportBtn){
@@ -1865,53 +1973,20 @@ der-radius:.4rem;background:transparent;color:inherit;}
         tempSubFields=normalized;
         renderSubFieldControls();
         showAlert(normalized.length?'Untertitel importiert.':'Keine Untertitel-Felder importiert. Es wird der Standard verwendet.');
+        scheduleOptionPersist(true);
       });
     }
 
-    elements.saveBtn.addEventListener('click',()=>{
-      elements.subList.querySelectorAll('.db-sub-input').forEach(input=>{
-        input.dispatchEvent(new Event('change'));
-      });
-      elements.ruleList.querySelectorAll('.db-rule-field').forEach(input=>{
-        input.dispatchEvent(new Event('change'));
-      });
-      state.config.title=elements.titleInput.value.trim();
-      const newPart=elements.selPart.value;
-      const partChanged=state.config.partField!==newPart;
-      state.config.partField=newPart;
-      const collected=(tempSubFields||[]).map(v=>v||'').filter(Boolean);
-      state.config.subFields=collected.length?collected:[getAvailableFieldList(state)[0]||DEFAULT_SUB_FIELD];
-      const preparedRules=(tempTitleRules||[]).map(rule=>normalizeTitleRule(rule)).map(rule=>({
-        field:(rule.field||'').trim(),
-        operator:normalizeOperator(rule.operator),
-        value:typeof rule.value==='string'?rule.value.trim():(rule.value==null?'':String(rule.value).trim()),
-        text:(rule.text||'').trim()
-      })).filter(rule=>rule.field&&rule.text);
-      state.config.titleRules=preparedRules;
-      state.config.colors={
-        bg:elements.cBg.value,
-        item:elements.cItem.value,
-        title:elements.cTitle.value,
-        sub:elements.cSub.value,
-        active:elements.cActive.value
-      };
-      refreshTitleBar();
-      applyColors(elements.root,state.config.colors);
-      if(partChanged){
-        state.items.forEach(item=>{
-          const raw=String(item.data?.[newPart]||'').trim();
-          const part=(raw.split(':')[0]||'').trim();
-          item.part=part;
-          item.data={...item.data,[newPart]:part};
-        });
-        state.excluded.clear();
-      }
-      persistState(state);
-      render();
-      closeOptions();
-    });
+    if(elements.titleInput){
+      elements.titleInput.addEventListener('input',()=>{scheduleOptionPersist();});
+      elements.titleInput.addEventListener('change',()=>{scheduleOptionPersist(true);});
+    }
 
-    elements.closeBtn.addEventListener('click',closeOptions);
+    [elements.cBg,elements.cItem,elements.cTitle,elements.cSub,elements.cActive].forEach(input=>{
+      if(!input) return;
+      input.addEventListener('input',()=>{scheduleOptionPersist();});
+      input.addEventListener('change',()=>{scheduleOptionPersist(true);});
+    });
 
     elements.selPart.addEventListener('change',()=>{
       const newPart=elements.selPart.value;
@@ -1974,6 +2049,11 @@ der-radius:.4rem;background:transparent;color:inherit;}
         elements.menu.remove();
         SHARED.clearAspenItems(instanceId);
         stopPolling();
+        if(optionPersistTimer){
+          clearTimeout(optionPersistTimer);
+          optionPersistTimer=null;
+        }
+        document.removeEventListener('keydown',handleGlobalKeydown);
         mo.disconnect();
       }
     });


### PR DESCRIPTION
## Summary
- remove the manual save/close controls from the Aspen board options panel to simplify the UI
- persist option changes automatically while editing and close the dialog when clicking outside or pressing Escape
- clean up timers and global listeners when the module is removed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd204f1b00832da150b993d00d51d9