### PR TITLE
Fix custom block creation handler

### DIFF
--- a/modules/NewStandardFindings/NewStandardFindings.js
+++ b/modules/NewStandardFindings/NewStandardFindings.js
@@ -402,6 +402,135 @@
     }
   }
 
+  let customAddDelegated=false;
+
+  function ensureCustomAddDelegation(){
+    if(customAddDelegated||typeof document==='undefined') return;
+    customAddDelegated=true;
+    document.addEventListener('click',event=>{
+      const target=event&&event.target instanceof Element
+        ?event.target.closest('.nsf-custom-add')
+        :null;
+      if(!target) return;
+      const tabKey=resolveCustomAddTabKey(target);
+      addCustomBlock(tabKey,'text');
+    });
+  }
+
+  function resolveCustomAddTabKey(button){
+    const ensureKey=value=>{
+      if(typeof value!=='string') return '';
+      return getRoutineEditorTabKey(value);
+    };
+    if(!button||typeof button!=='object') return 'routine';
+    try{
+      const dataset=button.dataset||{};
+      if(typeof dataset.tabKey==='string'&&dataset.tabKey){
+        return ensureKey(dataset.tabKey);
+      }
+      if(typeof dataset.tab==='string'&&dataset.tab){
+        return ensureKey(dataset.tab);
+      }
+      const attrTabKey=button.getAttribute?button.getAttribute('data-tab-key'):null;
+      if(typeof attrTabKey==='string'&&attrTabKey){
+        return ensureKey(attrTabKey);
+      }
+      const attrTab=button.getAttribute?button.getAttribute('data-tab'):null;
+      if(typeof attrTab==='string'&&attrTab){
+        return ensureKey(attrTab);
+      }
+      if(typeof button.closest==='function'){
+        const parent=button.closest('[data-tab-key],[data-tab]');
+        if(parent){
+          const parentDataset=parent.dataset||{};
+          if(typeof parentDataset.tabKey==='string'&&parentDataset.tabKey){
+            return ensureKey(parentDataset.tabKey);
+          }
+          if(typeof parentDataset.tab==='string'&&parentDataset.tab){
+            return ensureKey(parentDataset.tab);
+          }
+          const parentAttrKey=parent.getAttribute?parent.getAttribute('data-tab-key'):null;
+          if(typeof parentAttrKey==='string'&&parentAttrKey){
+            return ensureKey(parentAttrKey);
+          }
+          const parentAttrTab=parent.getAttribute?parent.getAttribute('data-tab'):null;
+          if(typeof parentAttrTab==='string'&&parentAttrTab){
+            return ensureKey(parentAttrTab);
+          }
+        }
+      }
+      return loadRoutineEditorActiveTab();
+    }catch{
+      return 'routine';
+    }
+  }
+
+  function bindCustomAddButtons(root=document){
+    if(typeof document==='undefined') return;
+    const scope=root&&typeof root.querySelectorAll==='function'?root:document;
+    const buttons=scope.querySelectorAll?scope.querySelectorAll('.nsf-custom-add'):[];
+    ensureCustomAddDelegation();
+    buttons.forEach(button=>{
+      if(!(button instanceof HTMLElement)) return;
+      if(button.dataset&&button.dataset.nsfCustomAddBound==='1') return;
+      button.addEventListener('click',event=>{
+        try{event.preventDefault();}
+        catch{}
+        try{event.stopPropagation();}
+        catch{}
+        const tabKey=resolveCustomAddTabKey(button);
+        addCustomBlock(tabKey,'text');
+      });
+      if(button.dataset) button.dataset.nsfCustomAddBound='1';
+    });
+  }
+
+  function addCustomBlock(tabKey,type='text'){
+    const targetTab=getRoutineEditorTabKey(tabKey);
+    let state;
+    try{
+      state=normalizeRoutineEditorState(loadRoutineEditorState());
+    }catch(err){
+      console.warn('NSF: Routine-Editor Zustand konnte nicht geladen werden',err);
+      state=createDefaultRoutineEditorState();
+    }
+    if(!state||typeof state!=='object'||!state.tabs){
+      state=createDefaultRoutineEditorState();
+    }
+    const tabState=normalizeRoutineEditorTabState(state.tabs[targetTab],targetTab);
+    const blockId=createCustomSectionId();
+    const blockType=type==='linebreak'?'linebreak':type==='aspen'?'aspen':'text';
+    const block={
+      id:blockId,
+      type:blockType,
+      label:'Neues Element',
+      aspenField:'',
+      lines:['']
+    };
+    if(blockType==='text'){
+      block.parameterKey='';
+    }
+    const customBlocks=Array.isArray(tabState.customBlocks)?tabState.customBlocks.slice():[];
+    customBlocks.push(block);
+    const customKey=`${ROUTINE_EDITOR_CUSTOM_PREFIX}${blockId}`;
+    const order=Array.isArray(tabState.order)?tabState.order.filter(entry=>entry!==customKey):[];
+    order.push(customKey);
+    tabState.customBlocks=customBlocks;
+    tabState.order=order;
+    state.tabs[targetTab]=tabState;
+    storeRoutineEditorState(state);
+    if(typeof renderRoutineEditor==='function'){
+      try{renderRoutineEditor();}
+      catch(err){console.warn('NSF: Routine-Editor konnte nicht aktualisiert werden',err);}
+    }
+    if(typeof requestAnimationFrame==='function'){
+      requestAnimationFrame(()=>bindCustomAddButtons(document));
+    }else{
+      bindCustomAddButtons(document);
+    }
+    return block;
+  }
+
   function cloneRoutineEditorTabState(state,tabKey){
     const normalized=normalizeRoutineEditorTabState(state,tabKey);
     const clone={
@@ -6406,4 +6535,12 @@
     instance.scheduleRender();
     return instance;
   };
+
+  if(typeof document!=='undefined'){
+    if(document.readyState==='loading'){
+      document.addEventListener('DOMContentLoaded',()=>bindCustomAddButtons(document),{once:true});
+    }else{
+      bindCustomAddButtons(document);
+    }
+  }
 })();


### PR DESCRIPTION
## Summary
- implement a centralized addCustomBlock helper that creates default blocks, updates the routine editor state, and triggers a re-render
- wire .nsf-custom-add buttons (with delegated fallback) so every tab can append new custom blocks using the shared helper
- initialize the custom add button bindings on DOM ready to keep the UI responsive to new elements

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd3bd2c888832d9682b95eb5ba6dc8