### PR TITLE
chore: bump module versions and changelog entries

### DIFF
--- a/modules/AspenComments/AspenComments.json
+++ b/modules/AspenComments/AspenComments.json
@@ -11,5 +11,5 @@
     "title": "Unit Comments"
   },
   "moduleId": "AspenComments",
-  "version": "1.2.0"
+  "version": "1.2.1"
 }

--- a/modules/AspenComments/Changelog.txt
+++ b/modules/AspenComments/Changelog.txt
@@ -5,6 +5,11 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 
 ---
 
+## [1.2.1] – 2025-10-02
+### Changed
+- Ausgewählte Kommentar- und Aspen-Dateien behalten nun ihren vollständigen Namen inklusive Unterordnerpfad und werden nach dem Laden in Status und Tooltips angezeigt.
+- Gespeicherte Datei-Handles setzen automatisch Pfad und Label, sobald eine Sitzung erneut geöffnet oder eine Datei neu verbunden wird.
+
 ## [1.2.0] – 2025-10-02
 ### Added
 - Kontextmenü mit Aktionen zum Auswählen, Erstellen, Neuladen und Löschen der Kommentar-Datei direkt im Modul.

--- a/modules/Gerätedaten/Changelog.txt
+++ b/modules/Gerätedaten/Changelog.txt
@@ -5,6 +5,11 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 
 ---
 
+## [1.5.1] – 2025-10-02
+### Fixed
+- Standardfeld-Erkennung nutzt nun eine erweiterte Kandidatenliste, sodass hinterlegte Basisfelder wieder korrekt mit Aspen-Spalten abgeglichen werden.
+- Die Auftragsspalte erkennt zusätzlich das Alias `AUFTRAGS_NO`, wodurch importierte Excel-Dateien mit diesem Header automatisch übernommen werden.
+
 ## [1.5.0] – 2025-10-02
 ### Added
 - Kopfzeile blendet automatisch den ermittelten Gerätenamen aus den Namensregeln ein und aktualisiert sich bei Änderungen am P/N-Feld.

--- a/modules/Gerätedaten/Gerätedaten.json
+++ b/modules/Gerätedaten/Gerätedaten.json
@@ -37,5 +37,5 @@
     ]
   },
   "moduleId": "Gerätedaten",
-  "version": "1.5.0"
+  "version": "1.5.1"
 }

--- a/modules/NewStandardFindings/Changelog.txt
+++ b/modules/NewStandardFindings/Changelog.txt
@@ -5,6 +5,11 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 
 ---
 
+## [1.3.1] – 2025-10-02
+### Changed
+- Routine-Editor speichert Eingaben in Text- und Aspen-Blöcken sofort im lokalen Zustand und aktualisiert deren Darstellung auch nach dem Neuladen.
+- Custom-Block-Renderer kennzeichnet Aspen-Felder mit einer eigenen CSS-Klasse und liefert detailliertere Konsolenmeldungen pro Blocktyp.
+
 ## [1.3.0] – 2025-10-02
 ### Added
 - Routine-Editor mit Overlay, Tabs und Drag-and-Drop-Blöcken ermöglicht das Zusammenstellen von Findings-, Actions-, Routine- und Nonroutine-Textbausteinen inklusive Aspen-Vorschau und Mehrfachausgaben.

--- a/modules/NewStandardFindings/NewStandardFindings.json
+++ b/modules/NewStandardFindings/NewStandardFindings.json
@@ -7,5 +7,5 @@
   "minW": 2,
   "minH": 12,
   "moduleId": "NewStandardFindings",
-  "version": "1.3.0"
+  "version": "1.3.1"
 }


### PR DESCRIPTION
## Summary
- bump Unit Comments to 1.2.1 with changelog notes about persistent Dateipfade
- bump New Standard Findings to 1.3.1 documenting Routine-Editor Blockpersistenz
- bump Gerätedaten to 1.5.1 including erweiterte Feldzuordnung und AUFTRAGS_NO Alias

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd943d87e0832db5a7cbea404cb967