### PR TITLE
chore: update findings editor version to 1.4.0

### DIFF
--- a/ShopguideChangelog.txt
+++ b/ShopguideChangelog.txt
@@ -5,6 +5,10 @@ Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und 
 
 ---
 
+## [3.6.6] – 2025-10-01
+### Changed
+- Shopguide Findings Editor auf Version 1.4.0 aktualisiert; Einträge können jetzt direkt dupliziert werden und Listenaktionen blenden sich nur noch bei Bedarf ein.
+
 ## [3.6.5] – 2025-09-29
 ### Added
 - New Standard Findings auf Version 1.2.3 angehoben; Dateiauswahl-Button und Kontextinfo zeigen nun den gespeicherten Findings-Pfad.

--- a/modules/ShopguideFindingsEditor/Changelog.txt
+++ b/modules/ShopguideFindingsEditor/Changelog.txt
@@ -3,6 +3,15 @@
 Alle relevanten Änderungen an diesem Modul werden hier dokumentiert.
 Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/) und [SemVer](https://semver.org/lang/de/).
 
+## [1.4.0] – 2025-10-01
+### Added
+- Schneller Duplizieren-Button in der Findings-Liste, der komplette Einträge inklusive Partnummern, Teilepaaren und Rohdaten kopiert.
+
+### Changed
+- Aktionsschaltflächen der Findings-Liste werden nun erst bei Hover oder Fokus eingeblendet, was die Oberfläche ruhiger und tastaturfreundlicher macht.
+
+---
+
 ## [1.3.0] – 2025-09-30
 ### Changed
 - Entferntes Speichern der Findings-Daten im Local Storage zugunsten eines konsequenten Schreibens in die ausgewählte JSON-Datei.

--- a/modules/ShopguideFindingsEditor/ShopguideFindingsEditor.js
+++ b/modules/ShopguideFindingsEditor/ShopguideFindingsEditor.js
@@ -1,7 +1,7 @@
 (function(){
   'use strict';
 
-  const MODULE_VERSION='1.3.0';
+  const MODULE_VERSION='1.4.0';
   const PATH_KEY='shopguide-findings-path';
   const GLOBAL_PATH_STORAGE_KEY='shopguide-findings-global-path';
   const DEFAULT_FILE='Shopguide_Findings.json';

--- a/modules/ShopguideFindingsEditor/ShopguideFindingsEditor.json
+++ b/modules/ShopguideFindingsEditor/ShopguideFindingsEditor.json
@@ -7,5 +7,5 @@
   "minW": 4,
   "minH": 10,
   "moduleId": "ShopguideFindingsEditor",
-  "version": "1.3.0"
+  "version": "1.4.0"
 }


### PR DESCRIPTION
## Summary
- bump the Shopguide Findings Editor module version to 1.4.0 in the runtime constant and manifest
- document the new duplicate action and hover-only list controls in the module and application changelogs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de23d38c0c832da2b27e90af8b66d8