### PR TITLE
Prevent NewStandardFindings input from stealing focus

### DIFF
--- a/modules/NewStandardFindings/NewStandardFindings.js
+++ b/modules/NewStandardFindings/NewStandardFindings.js
@@ -6931,7 +6931,17 @@
       if(prefillEntry){
         this.lockRow(state,prefillEntry,{persist:false,updateState:false,syncOutputs:false});
       }else if(focusNext){
-        setTimeout(()=>{if(!state.locked) input.focus();},60);
+        setTimeout(()=>{
+          if(state.locked) return;
+          const active=document.activeElement;
+          const root=this.root instanceof HTMLElement?this.root:null;
+          if(active&&active!==document.body){
+            const isActiveInRoot=root&&root.contains(active);
+            const isDisconnected=active instanceof Node&&!active.isConnected;
+            if(!isActiveInRoot&&!isDisconnected) return;
+          }
+          input.focus();
+        },60);
       }
     }
 


### PR DESCRIPTION
## Summary
- update the NewStandardFindings auto-focus logic to skip focusing when another module currently owns the active element

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de61879220832dbe13f4d329ea4115