### PR TITLE
Update findings editor to use RoutineAction field

### DIFF
--- a/Shopguide_Findings.json
+++ b/Shopguide_Findings.json
@@ -7,7 +7,7 @@
     "label": "Demo-Eintrag",
     "findings": "Beispielbefund zur Demonstration des Editors.",
     "actions": "Erforderliche Maßnahme dokumentieren.",
-    "routine": "Routinebeschreibung eintragen.",
+    "routineAction": "KV-Aktion eintragen.",
     "nonroutine": "Besondere Hinweise für Nonroutine-Fälle ergänzen.",
     "parts": "Artikelnummern oder Bestellhinweise hier aufführen."
   }


### PR DESCRIPTION
## Summary
- rename the routine field to routineAction and surface it as "KV-Actions" in the findings editor UI
- update JSON parsing/serialization to read and write RoutineAction instead of RoutineFinding
- adjust bundled demo data to use the new routineAction field

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de83508b98832da4bb643b06fa1d3b