### PR TITLE
Reduce AspenBoard polling interval to 5 seconds

### DIFF
--- a/modules/AspenUnitList/AspenBoard.js
+++ b/modules/AspenUnitList/AspenBoard.js
@@ -1728,7 +1728,7 @@
   window.renderAspenBoard=async function(targetDiv,opts){
     let lastModifiedCheck=null;
     let pollInterval=null;
-    const POLL_INTERVAL_MS=60000;
+    const POLL_INTERVAL_MS=5000;
     let pollInProgress=false;
     injectStyles();
 


### PR DESCRIPTION
## Summary
- lower the Aspen board polling interval constant to 5 seconds for more frequent refreshes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de905b3d94832db25dee1db28dea4e