### PR TITLE
Fix active highlight for Aspen extra columns

### DIFF
--- a/modules/AspenUnitList/AspenBoard.js
+++ b/modules/AspenUnitList/AspenBoard.js
@@ -3394,6 +3394,7 @@
         saveDoc(doc);
         updateHighlights(elements.list);
         if(elements.activeList) updateHighlights(elements.activeList);
+        if(elements.extraContainer) updateHighlights(elements.extraContainer);
         window.dispatchEvent(new Event(CUSTOM_BROADCAST));
       }
     };
@@ -3417,6 +3418,7 @@
     const refreshHighlights=()=>{
       updateHighlights(elements.list);
       if(elements.activeList) updateHighlights(elements.activeList);
+      if(elements.extraContainer) updateHighlights(elements.extraContainer);
     };
     window.addEventListener('storage',event=>{if(event.key===LS_DOC) refreshHighlights();});
     window.addEventListener(CUSTOM_BROADCAST,refreshHighlights);


### PR DESCRIPTION
## Summary
- ensure selecting a device updates the active highlight within extra Aspen columns
- keep extra-column highlights in sync when highlights refresh via events

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e3956c846c832da72153d3d3e99bde