### PR TITLE
Fix DragDropSyncTest layout capture fallback

### DIFF
--- a/modules/DragDropSyncTest/DragDropSyncTest.js
+++ b/modules/DragDropSyncTest/DragDropSyncTest.js
@@ -80,6 +80,11 @@
     console.log(`${LOG_PREFIX} ${action}`, ...details);
   }
 
+  function toNumberOr(value, fallback){
+    const num = Number(value);
+    return Number.isFinite(num) ? num : fallback;
+  }
+
   function createState(root){
     return {
       root,
@@ -365,10 +370,10 @@
       });
       modules[moduleKey] = {
         layout: {
-          x: node.x ?? Number(moduleEntry.item.dataset.gsX) || 0,
-          y: node.y ?? Number(moduleEntry.item.dataset.gsY) || 0,
-          w: node.w ?? Number(moduleEntry.item.dataset.gsW) || 4,
-          h: node.h ?? Number(moduleEntry.item.dataset.gsH) || 3
+          x: node.x ?? toNumberOr(moduleEntry.item.dataset.gsX, 0),
+          y: node.y ?? toNumberOr(moduleEntry.item.dataset.gsY, 0),
+          w: node.w ?? toNumberOr(moduleEntry.item.dataset.gsW, 4),
+          h: node.h ?? toNumberOr(moduleEntry.item.dataset.gsH, 3)
         },
         chips
       };


### PR DESCRIPTION
## Summary
- add a helper to normalize numeric dataset values in DragDropSyncTest
- ensure layout capture uses the helper to avoid syntax errors when mixing nullish coalescing with logical OR

## Testing
- node - <<'NODE'
const fs = require('fs');
const vm = require('vm');
const code = fs.readFileSync('modules/DragDropSyncTest/DragDropSyncTest.js', 'utf8');
const sandbox = {
  window: {},
  document: {
    head: { appendChild() {} },
    createElement(){ return { dataset:{}, classList:{add(){},remove(){}}, appendChild(){}, querySelector(){return null;}, querySelectorAll(){return[];}, innerHTML:'', textContent:'', style:{}, className:'', setAttribute(){}, addEventListener(){}, removeEventListener(){}, closest(){return null;}}; },
    getElementById(){return null;}
  },
  console,
  setInterval(){},
  clearInterval(){},
  CSS: { escape: s => s }
};
sandbox.window = sandbox.window;
vm.createContext(sandbox);
try {
  vm.runInContext(code, sandbox);
  console.log('ok');
} catch (err) {
  console.error('error', err);
}
NODE

------
https://chatgpt.com/codex/tasks/task_e_68e3d5f6c9d4832d98e184393ab7a91f